### PR TITLE
Fix remote addition for private repositories

### DIFF
--- a/ome_merge.py
+++ b/ome_merge.py
@@ -314,7 +314,10 @@ class OME(object):
         dbg("## Unique users: %s", self.unique_logins)
         for user in self.unique_logins:
             key = "merge_%s" % user
-            url = "git://github.com/%s/%s.git" % (user, self.name)
+            if self.repo.private:
+                url = "git@github.com:%s/%s.git"  % (user, self.name)
+            else:
+                url = "git://github.com/%s/%s.git" % (user, self.name)
             self.call("git", "remote", "add", key, url)
             self.remotes[key] = url
             self.call("git", "fetch", key)


### PR DESCRIPTION
Can be tested on a private repository, e.g. `openmicroscopy/qa`
