### PR TITLE
SCC Refactor I

### DIFF
--- a/ome_merge.py
+++ b/ome_merge.py
@@ -498,14 +498,14 @@ if __name__ == "__main__":
     filters["base"] = args.base
     filters["include"] = args.include
     filters["exclude"] = args.exclude
-    Repo = Repository(filters, args.reset)
+    main_repo = Repository(filters, args.reset)
     try:
         if not args.info:
-            Repo.merge(args.comment)
-        Repo.submodules(args.info, args.comment)  # Recursive
+            main_repo.merge(args.comment)
+        main_repo.submodules(args.info, args.comment)  # Recursive
 
         if args.buildnumber:
             newbranch = "HEAD:%s/%g" % (args.base, args.build_number)
             call("git", "push", "team", newbranch)
     finally:
-        Repo.cleanup()
+        main_repo.cleanup()


### PR DESCRIPTION
This PR is a first step in the refactoring of snoopycrimecop for 4.4.6/4.5. Most of the refactor commits have been inspired by the pylint report:
- reduce the number of class attributes in favor of methods
- rename classes
- separate specific components into separate methods, e.g. find_candidates
- create a filters dictionary 

Post-merge steps shoudl be:
- truly separate Git/ GithubAPI components into standalone DAOs
- mock these classes and implement tests
