### PR TITLE
Always merge

### DIFF
--- a/ome_merge.py
+++ b/ome_merge.py
@@ -310,8 +310,8 @@ class Repository(object):
     def fast_forward(self, base, remote = "origin"):
         """Execute merge --ff-only against the current base"""
         dbg("## Merging base to ensure closed PRs are included.")
-        p = call("git", "merge", "--ff-only", remote + "/" + base, stdout = subprocess.PIPE).communicate()
-        log.info(p.rstrip("\n"))
+        p = subprocess.Popen(["git", "merge", "--ff-only", "%s/%s" % (remote, base)], stdout = subprocess.PIPE).communicate()[0]
+        log.info(p.rstrip("/n"))
 
     def merge(self, comment=False):
         """Merge candidate pull requests."""


### PR DESCRIPTION
Fix issue reported in #13 as well as other bugs
- fix bug when recording conflicting PRs list
- Use `reset --hard``rather than``merge --ff-only``because the latter command seemed to hang on a couple of times when calling``p.wait`` in the call command

This script has been successfully tested with the builds 70 and 71 of the [OMERO-merge-4.4](http://hudson.openmicroscopy.org.uk/view/4.4/job/OMERO-merge-4.4/) job.
