### PR TITLE
Fix merge command when PR owner differs from branch head owner

### DIFF
--- a/scc.py
+++ b/scc.py
@@ -348,6 +348,10 @@ class PullRequest(object):
         """Return the number of the Pull Request."""
         return int(self.pull.issue_url.split("/")[-1])
 
+    def get_head_login(self):
+        """Return the login of the branch where the changes are implemented."""
+        return self.pull.head.user.login
+
     def get_sha(self):
         """Return the SHA1 of the head of the Pull Request."""
         return self.pull.head.sha
@@ -616,7 +620,7 @@ class GitRepository(object):
         """Return a set of unique logins."""
         unique_logins = set()
         for pull in self.candidate_pulls:
-            unique_logins.add(pull.get_login())
+            unique_logins.add(pull.get_head_login())
         return unique_logins
 
     def remotes(self):


### PR DESCRIPTION
See #2 for an example of such scenario.
To test this PR, 
- merge it locally 
- add label to exclude it from the merge command, 
- run
  `scc.py merge master --exclude exclude-label --include include`
- check #2 is merged.
