### PR TITLE
Logging is gobbled for call methods.

### DIFF
--- a/scc.py
+++ b/scc.py
@@ -637,7 +637,7 @@ class GitRepository(object):
 
         if stderr or p.returncode:
             print "Error output was:\n%s" % stderr
-            print "Output was:\n%s" % stdout
+            print "Output was:\n%s" % revlist
             return False
 
         return revlist.splitlines()


### PR DESCRIPTION
With debug off:

```
$ scc rebase 546 develop
Traceback (most recent call last):
  File "/usr/local/bin/scc", line 1142, in <module>
    main()
  File "/usr/local/bin/scc", line 1138, in main
    ns.func(ns)
  File "/usr/local/bin/scc", line 990, in __call__
    self.rebase(args, main_repo)
  File "/usr/local/bin/scc", line 1017, in rebase
    branching_sha1[0:6], pr_head)
  File "/usr/local/bin/scc", line 623, in rebase
    "%s" % newbase, "%s" % upstream, "%s" % sha1)
  File "/usr/local/bin/scc", line 483, in call
    raise Exception("rc=%s" % rc)
Exception: rc=1
```

With debug on:

```
...
2012-12-14 08:29:10,809 INFO  [         scc] Merged: True
2012-12-14 08:29:10,814 DEBUG [         scc] Calling 'git rev-list --first-parent 21025952b71e435dd960f5fab561cced1249ad74'
2012-12-14 08:29:11,002 DEBUG [         scc] Calling 'git rev-list --first-parent origin/dev_4_4'
2012-12-14 08:29:11,224 INFO  [         scc] Branching SHA1: 7e4636
2012-12-14 08:29:11,227 DEBUG [         scc] Calling 'git rebase --onto origin/develop 7e4636 21025952b71e435dd960f5fab561cced1249ad74'
2012-12-14 08:29:11,406 DEBUG [         scc] Cannot rebase: You have unstaged changes.
2012-12-14 08:29:11,431 DEBUG [         scc] Please commit or stash them.
Traceback (most recent call last):
  File "/usr/local/bin/scc", line 1142, in <module>
    main()
  File "/usr/local/bin/scc", line 1138, in main
    ns.func(ns)
  File "/usr/local/bin/scc", line 990, in __call__
    self.rebase(args, main_repo)
  File "/usr/local/bin/scc", line 1017, in rebase
    branching_sha1[0:6], pr_head)
  File "/usr/local/bin/scc", line 623, in rebase
    "%s" % newbase, "%s" % upstream, "%s" % sha1)
  File "/usr/local/bin/scc", line 483, in call
    raise Exception("rc=%s" % rc)
Exception: rc=1
```
