### PR TITLE
Fix logging by setting right global variable

### DIFF
--- a/scc.py
+++ b/scc.py
@@ -45,9 +45,9 @@ import difflib
 SCC_DEBUG_LEVEL = logging.INFO
 if "SCC_DEBUG_LEVEL" in os.environ:
     try:
-        log_level = int(os.environ.get("SCC_DEBUG_LEVEL"))
+        SCC_DEBUG_LEVEL = int(os.environ.get("SCC_DEBUG_LEVEL"))
     except:
-        log_level = 10 # Assume poorly formatted means "debug"
+        SCC_DEBUG_LEVEL = 10 # Assume poorly formatted means "debug"
 
 
 #


### PR DESCRIPTION
`log_level` was being set rather than SCC_DEBUG_LEVEL
which essentially disabled support for the env variables
even though `-q` and `-v` were working properly.

Now the following should all work:

```
@fix_logging_2 ~/code/scc.git $ ./scc.py merge master -v
10
@fix_logging_2 ~/code/scc.git $ SCC_DEBUG_LEVEL=40 ./scc.py merge master -v
30
@fix_logging_2 ~/code/scc.git $ SCC_DEBUG_LEVEL=40 ./scc.py merge master
40
@fix_logging_2 ~/code/scc.git $ SCC_DEBUG_LEVEL=10 ./scc.py merge master
10
@fix_logging_2 ~/code/scc.git $ SCC_DEBUG_LEVEL=10 ./scc.py merge master -q
20
```
