### PR TITLE
object of type 'bool' has no len()

### DIFF
--- a/scc.py
+++ b/scc.py
@@ -653,9 +653,10 @@ class GitRepository(object):
         (revlist, stderr) = p.communicate('')
 
         if stderr or p.returncode:
-            print "Error output was:\n%s" % stderr
-            print "Output was:\n%s" % revlist
-            return False
+            msg = "Error output was:\n%s" % stderr
+            if revlist.strip():
+                msg += "Output was:\n%s" % revlist
+            raise Exception(msg)
 
         return revlist.splitlines()
 


### PR DESCRIPTION
Error arose when a local commit was not present. I.e. this error would not have been seen had there been a `--fetch` invoked, but it should still be investigated.

```
@(2e32665...) ~/git/docs/sphinx $ ~/code/scc.git/scc.py rebase -v 183 develop
2012-12-17 09:53:33,757 DEBUG [     scc.git] Check current status
2012-12-17 09:53:33,757 DEBUG [     scc.git] Calling 'git log --oneline -n 1 HEAD'
2012-12-17 09:53:33,806 DEBUG [     scc.git] 2e32665 Merge pull request #97 from sbesson/env_makefile
2012-12-17 09:53:33,806 DEBUG [     scc.git] Calling 'git submodule status'
2012-12-17 09:53:34,778 DEBUG [     scc.git] Calling 'git config --get remote.origin.url'
2012-12-17 09:53:34,786 INFO  [     scc.git] Repository: openmicroscopy/ome-documentation
2012-12-17 09:53:34,787 DEBUG [      scc.gh] github.get_user
2012-12-17 09:53:36,182 DEBUG [      scc.gh] github.get_organization
2012-12-17 09:53:36,913 DEBUG [     scc.git] Calling 'git config --get remote.origin.url'
2012-12-17 09:53:36,921 INFO  [     scc.git] Repository: openmicroscopy/ome-documentation
2012-12-17 09:53:36,921 DEBUG [     scc.git] Get current head
2012-12-17 09:53:36,922 DEBUG [     scc.git] Calling 'git symbolic-ref HEAD' for stdout/err
2012-12-17 09:53:36,928 DEBUG [     scc.git] Get current sha1
2012-12-17 09:53:36,929 DEBUG [     scc.git] Calling 'git rev-parse HEAD' for stdout/err
2012-12-17 09:53:38,507 INFO  [  scc.rebase] PR 183: Fix links to Numpy/Scipy downloads page opened by Sébastien Besson against dev_4_4
2012-12-17 09:53:38,508 INFO  [  scc.rebase] Head: 505685
2012-12-17 09:53:39,194 INFO  [  scc.rebase] Merged: False
2012-12-17 09:53:39,200 DEBUG [     scc.git] Calling 'git rev-list --first-parent 505685666a8e88b09ef7d401d84e9b08c958106f'
Error output was:
fatal: bad object 505685666a8e88b09ef7d401d84e9b08c958106f

Output was:

2012-12-17 09:53:39,265 DEBUG [     scc.git] Calling 'git rev-list --first-parent origin/dev_4_4'
Traceback (most recent call last):
  File "/Users/moore/code/scc.git/scc.py", line 1166, in <module>
    main()
  File "/Users/moore/code/scc.git/scc.py", line 1162, in main
    ns.func(ns)
  File "/Users/moore/code/scc.git/scc.py", line 1014, in __call__
    self.rebase(args, main_repo)
  File "/Users/moore/code/scc.git/scc.py", line 1039, in rebase
    "%s/%s" % (args.remote, pr.base.ref))
  File "/Users/moore/code/scc.git/scc.py", line 735, in find_branching_point
    matching_block = s.get_matching_blocks()
  File "/System/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/difflib.py", line 482, in get_matching_blocks
    la, lb = len(self.a), len(self.b)
TypeError: object of type 'bool' has no len()
```
