### PR TITLE
Add AlreadyMerged command

### DIFF
--- a/scc.py
+++ b/scc.py
@@ -876,6 +876,53 @@ class Command(object):
         logging.getLogger('github').setLevel(logging.INFO)
 
 
+class AlreadyMerged(Command):
+    """Detect branches local & remote which are already merged"""
+
+    NAME = "already-merged"
+
+    def __init__(self, sub_parsers):
+        super(AlreadyMerged, self).__init__(sub_parsers)
+        self.add_token_args()
+
+        self.parser.add_argument("target",
+                help="Head to check against. E.g. master or origin/master")
+        self.parser.add_argument("ref", nargs="*",
+                default=["refs/heads", "refs/remotes"],
+                help="List of ref patterns to be checked. E.g. refs/remotes/origin")
+
+    def __call__(self, args):
+        super(AlreadyMerged, self).__call__(args)
+        self.login(args)
+
+        main_repo = self.gh.git_repo(self.cwd, False)
+        try:
+            self.already_merged(args, main_repo)
+        finally:
+            main_repo.cleanup()
+
+    def already_merged(self, args, main_repo):
+        fmt = "%(committerdate:iso8601) %(refname:short)   --- %(subject)"
+        cmd = ["git", "for-each-ref", "--sort=committerdate"]
+        cmd.append("--format=%s" % fmt)
+        cmd += args.ref
+        proc = main_repo.call(*cmd, stdout=subprocess.PIPE)
+        out, err = proc.communicate()
+        for line in out.split("\n"):
+            if line:
+                self.go(main_repo, line.rstrip(), args.target)
+
+    def go(self, main_repo, input, target):
+        parts = input.split(" ")
+        branch = parts[3]
+        tip, err = main_repo.call("git", "rev-parse", branch,
+            stdout=subprocess.PIPE).communicate()
+        mrg, err = main_repo.call("git", "merge-base", branch, target,
+            stdout=subprocess.PIPE).communicate()
+        if tip == mrg:
+            print input
+
+
 class CleanSandbox(Command):
     """Cleans snoopys-sandbox repo after testing
 


### PR DESCRIPTION
`scc already-merged` now provides a way to check which branches both local and
remote can be removed. Anything not listed should be inspected for removal.

Example:

```
@already-merged ~/code/scc.git $ ./scc.py already-merged origin/master refs/heads
...
2012-12-17 00:57:39 -0800 master   --- Merge pull request #23 from joshmoore/fix_logging
2012-12-17 10:01:54 +0100 check_pygithub   --- Remove static FACTORY in favor of create_instance
2012-12-17 10:08:07 +0100 logging_fix   --- Add logger to PullRequest class
2012-12-17 10:54:48 +0100 fix_logging_2   --- Fix logging by setting right global variable
2012-12-17 12:40:18 -0800 already-merged   --- Merge pull request #28 from joshmoore/fix_logging_2
```

Usage questions:
- default to the current branch rather than specifying the target (here `origin/master`)
- allow specifying the format and the ordering?
- other "better" defaults?
- encourage users to fetch first?
- allow printing out courses of action? e.g. `git branch -d foo`
