### PR TITLE
remote_info check and other improvements

### DIFF
--- a/scc.py
+++ b/scc.py
@@ -713,7 +713,9 @@ class GitRepository(object):
                 stderr = subprocess.PIPE).communicate()[0]
         except:
             self.dbg("git config --get remote failure", exc_info=1)
-            raise Stop("Failed to find remote: %s. Check the --remote= argument." % remote_name)
+            remotes = self.call("git", "remote", stdout = subprocess.PIPE,
+                stderr = subprocess.PIPE).communicate()[0]
+            raise Stop("Failed to find remote: %s.\nAvailable remotes: %s can be passed with the --remote argument." % (remote_name, ", ".join(remotes.split("\n")[:-1])))
 
         # Read user from origin URL
         dirname = os.path.dirname(originurl)


### PR DESCRIPTION
Feedback from @jburel about `scc rebase`. In
general, the error messages need to be far
more friendly which something unexpected
happens.
