### PR TITLE
Check version against openmicroscopy user

### DIFF
--- a/scc.py
+++ b/scc.py
@@ -1304,7 +1304,7 @@ class Version(Command):
         self.dbg("hash_object: %s", self.blob)
 
         gh = get_github(get_token(), dont_ask=True)
-        self.repo = gh.gh_repo("snoopycrimecop", "snoopycrimecop")
+        self.repo = gh.gh_repo("snoopycrimecop", "openmicroscopy")
 
         found = self.search_heads()
         if not found:


### PR DESCRIPTION
When the main repository moved from scc to ome, the Version command was not
updated to look for tags from the right location which lead to
"unknown" being printed for 0.2.1.

/cc @sbesson
