### PR TITLE
Handle KeyboardInterrupt on "Enter password"

### DIFF
--- a/scc.py
+++ b/scc.py
@@ -199,9 +199,12 @@ class GHManager(object):
                     raise
                 import getpass
                 msg = "Enter password for http://github.com/%s:" % self.login_or_token
-                password = getpass.getpass(msg)
-                if password is not None:
-                    self.create_instance(self.login_or_token, password)
+                try:
+                    password = getpass.getpass(msg)
+                    if password is not None:
+                        self.create_instance(self.login_or_token, password)
+                except KeyboardInterrupt:
+                    raise Stop("Interrupted by the user")
         else:
             self.create_instance()
 


### PR DESCRIPTION
```
(8c580d4...) ~/code/scc.git $ ./scc.py already-merged HEAD
Enter password for http://github.com/joshmoore:Traceback (most recent call last):
  File "./scc.py", line 1699, in <module>
    main()
  File "./scc.py", line 1694, in main
    ns.func(ns)
  File "./scc.py", line 1132, in __call__
    self.login(args)
  File "./scc.py", line 1031, in login
    self.gh = get_github(token, dont_ask=args.no_ask)
  File "./scc.py", line 151, in get_github
    return GHManager(login_or_token, password, **kwargs)
  File "./scc.py", line 170, in __init__
    self.authorize(password)
  File "./scc.py", line 201, in authorize
    password = getpass.getpass(msg)
  File "/System/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/getpass.py", line 68, in unix_getpass
    passwd = _raw_input(prompt, stream, input=input)
  File "/System/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/getpass.py", line 128, in _raw_input
    line = input.readline()
KeyboardInterrupt
```
