### PR TITLE
Add --continue option to rebase

### DIFF
--- a/scc.py
+++ b/scc.py
@@ -1503,7 +1503,7 @@ class Rebase(Command):
                     "%s/%s" % (args.remote, pr.base.ref))
             try:
                 main_repo.rebase("%s/%s" % (args.remote, args.newbase),
-                    branching_sha1[0:6], pr_head)
+                    branching_sha1, pr_head)
             except:
                 raise Stop(20, "rebasing failed.\nFix conflicts and re-run with an additional --continue flag")
 


### PR DESCRIPTION
This allows naming and pushing the PR to
continue even after a rebase conflict.
(The renaming may should happen before
the call to rebase)
