### PR TITLE
Fix get_remote_info when remote is https://github.com/user/repo/

### DIFF
--- a/scc.py
+++ b/scc.py
@@ -798,7 +798,9 @@ class GitRepository(object):
         try:
             originurl = self.call("git", "config", "--get", \
                 "remote." + remote_name + ".url", stdout = subprocess.PIPE, \
-                stderr = subprocess.PIPE).communicate()[0]
+                stderr = subprocess.PIPE).communicate()[0].rstrip("\n")
+            if originurl[-1] == "/":
+                originurl = originurl[:-1]
         except:
             self.dbg("git config --get remote failure", exc_info=1)
             remotes = self.call("git", "remote", stdout = subprocess.PIPE,


### PR DESCRIPTION
```
git clone https://github.com/ome/scripts/
scc merge --info dev_4_4
```

will raise an exception without this PR and should work again with this commit
