### PR TITLE
Re-add MANIFEST.in post-0.3.1 release

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include LICENSE.txt
+include README.rst
+include requirements.txt
+include scc_version.py
+include RELEASE-VERSION


### PR DESCRIPTION
For a local install (./setup.py install) the files listed in setup.py suffice,
but for sdist, files like scc_version.py must also be listed in MANIFEST.in in
order to be included.
