### PR TITLE
Fix broken logic in merge command (--push argument)

### DIFF
--- a/scc.py
+++ b/scc.py
@@ -927,7 +927,7 @@ class GitRepository(object):
             merge_msg += self.fast_forward(filters["base"])  + "\n"
             merge_msg += self.merge(comment, commit_id = commit_id)
             postsha1 = self.get_current_sha1()
-            updated = (presha1 != postsha)
+            updated = (presha1 != postsha1)
 
         for filt in ["include", "exclude"]:
             filters[filt]["pr"] = None


### PR DESCRIPTION
The logic used to determine the `update` flag in `rmerge` is currently broken because:
- fast-forwards and merges in the parent repo are not accounted for
- submodule update status can override this

Concrete example: the [SCC-merge](http://hudson.openmicroscopy.org.uk/view/Mgmt/job/SCC-merge/) self-merge step cannot push to `merge/master/latest`.This PR should fix this logic.

Since this is a major bug, I suggest once this PR and #73 get reviewed and merged we tag 0.3.3 and upload to pypi.
