### PR TITLE
Need for @chdir for `git submodule status`

### DIFF
--- a/scc.py
+++ b/scc.py
@@ -582,7 +582,9 @@ class GitRepository(object):
         self.infoWrap = LoggerWrapper(self.log, logging.INFO)
 
         self.gh = gh
-        self.path =  os.path.abspath(path)
+        self.cd(path)
+        root_path, e = self.communicate("git", "rev-parse", "--show-toplevel")
+        self.path =  os.path.abspath(root_path.strip())
 
         self.get_status()
 


### PR DESCRIPTION
```
~/git/docs $ ~/code/scc.git/scc.py check-milestone v4.4.5 origin/dev_4_4 -v
2013-02-06 14:33:25,440 [  scc.config] DEBUG Found github.user
Enter password for http://github.com/joshmoore:
2013-02-06 14:33:31,834 [     scc.git] DEBUG Check current status
2013-02-06 14:33:31,834 [     scc.git] DEBUG Calling 'git log --oneline -n 1 HEAD'
2013-02-06 14:33:31,848 [     scc.git] DEBUG 87ff382 Add PyramidService.getResolutionDescriptions method (See #9813)
2013-02-06 14:33:31,849 [     scc.git] DEBUG Calling 'git submodule status'
2013-02-06 14:33:31,877 [     scc.git] DEBUG You need to run this command from the toplevel of the working tree.
```
