### PR TITLE
Add logic to create tag while updating submodules

### DIFF
--- a/scc.py
+++ b/scc.py
@@ -2158,6 +2158,8 @@ class UpdateSubmodules(GitRepoCommand):
         try:
             if args.message is None:
                 args.message = "Update %s submodules" % args.base
+                if args.tag:
+                    args.message += " for tag %s" % args.tag
             self.log.info(args.message)
             updated = self.submodules(args, self.main_repo)
 


### PR DESCRIPTION
- Add logic to tag Git repositories
- Implement tagging logic as option in update-submodules

See openmicroscopy/snoopys-sandbox#125 as an example generated locally with

```
$ git checkout origin/dev_4_4 && git submodule update
$ python ~/code/scc/scc.py update-submodules --tag test --push tag dev_4_4
```

NB: not sure if merging openmicroscopy/snoopys-sandbox#125 through the GH interface would push the tag created in the submodule. But as discussed with @joshmoore, we may want to signoff and push tags manuallt when accepting releases anyways
