### PR TITLE
Add support for Github commit status

### DIFF
--- a/scc.py
+++ b/scc.py
@@ -947,7 +947,9 @@ class GitRepository(object):
         msg = ""
         msg += str(self.origin) + "\n"
         self.origin.find_candidates(filters)
-        if not info:
+        if info:
+            msg += self.origin.merge_info()
+        else:
             msg += self.set_commit_status(status, message, url)
 
         for submodule_repo in self.submodules:


### PR DESCRIPTION
_For review and testing_

Github supports a [commit status feature](https://github.com/blog/1227-commit-status-api).

This adds a new `--set-commit-status` flag to the `merge` command, which will create a success or failure status on the latest commit of all PRs in the merge, depending if all PRs could be merged or not.

It also adds a `set-commit-status` command that takes options similar to the `merge` command in addition to `status`, `message`, and `url` options.  It uses the same logic as `merge` to find which PRs apply and then sets the given commit status on those PRs.  `--info` is supported to see which PRs apply without setting the status.
