### PR TITLE
Unrebased PRs improvement

### DIFF
--- a/test/TestUnrebasedPRs.py
+++ b/test/TestUnrebasedPRs.py
@@ -35,10 +35,10 @@ class UnitTestCheck(MockTest):
         self.m2 = {}
 
     def runCheck(self):
-        self.assertEqual(UnrebasedPRs.check(self.d1, self.d2),
-                         (self.m1, self.m2))
-        self.assertEqual(UnrebasedPRs.check(self.d2, self.d1),
-                         (self.m2, self.m1))
+        self.assertEqual(UnrebasedPRs.check_directed_links(self.d1, self.d2),
+                         self.m2)
+        self.assertEqual(UnrebasedPRs.check_directed_links(self.d2, self.d1),
+                         self.m1)
 
     def testEmptyDictionaries(self):
         self.runCheck()


### PR DESCRIPTION
Following discussion of September 4th, this PR starts refactoring the unrebased prs command to parse the PRs comments as well as notes.

Changes included in this PR:
- converts the `UnrebasedPRs` command as a subclass of `GitRepoCommand` (to reuse the `GithubRepository` machinery)
- parses `--rebased*` or `--no-rebase*` lines in pull requests comments without any see also note
- parses `--rebased*` or `--no-rebase*` lines of pull requests bodies without any rebase note
- move `merge_base()` as a low-level git function of `GitRepository`

Testing scenario:
The openmicroscopy/ome-documentation#451 and openmicroscopy/ome-documentation#457 PRs are good candidates without notes. The proposed naming scheme is currently `--rebased-to #pr` for the initial PR and `--rebased-from #pr` for the rebased PR.

From this branch,

```
$ python ~/code/ome/scc/scc.py unrebased-prs dev_4_4 develop
```

should not list any of these two PRs while the last release of `scc` should list them:

```
$ ~/virtualenv/bin/scc unrebased-prs dev_4_4 develop
```

Next immediate steps for this PR:
- [x] extend `scc rebase` to add comments to the source and target pull requests
- [x] add `--no-rebase` to update-submodules generated PRs
- [x] add `check` step to compare mismatching PR comments

Other suggestions (maybe outside the scope of this PR):
- [ ] teach `scc unrebased-prs` to run recursively across submodules
- [ ] add `--no-fetch` option and fetch `origin` and `notes` before checking unrebased PRs
- [ ] optimize parsing speed (keep rebased PR numbers in memory)
- [ ] refactor `scc unrebased-prs --write` to generate `git notes` commands from the parsed PR comments
- [ ] allow unrebased PRs to be grouped by login rather than by time
- [x] add command to to check when one side of the PR doesn't have the matching value and to force add it
- [ ] add command to drop all notes and synchronize them with the labels (or vice-versa)

/cc @jburel, @melissalinkert, @mtbc, @joshmoore
