### PR TITLE
Extend level size in logger format to properly display DEBUG logs

### DIFF
--- a/scc.py
+++ b/scc.py
@@ -1381,7 +1381,7 @@ class Command(object):
         self.log_level += args.quiet * 10
         self.log_level -= args.verbose * 10
 
-        log_format = """%(asctime)s [%(name)12.12s] %(levelname)-5.5s""" \
+        log_format = """%(asctime)s [%(name)12.12s] %(levelname)-6.6s""" \
             """%(message)s"""
         logging.basicConfig(level=self.log_level, format=log_format)
         logging.getLogger('github').setLevel(logging.INFO)


### PR DESCRIPTION
This commit should fix DEBUG log lines which currently display as

```
2013-09-18 05:01:47,511 [  scc.config] DEBUGFound github.token
```

/cc @bpindelski
