### PR TITLE
Rewrite readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ The list of available commands can be listed with::
 
   $ scc -h
 
-For each subcommand, additional help can be queried::
+For each subcommand, additional help can be queried, e.g.::
 
   $ scc merge -h
 


### PR DESCRIPTION
This PR fully rewrites the Readme page which is used as the landing page of the Github repository as well as the landing page of the Pypi page https://pypi.python.org/pypi/scc.

These improvement should improve the description of the requirements for installing and testing the package. More importantly, it should clarify the minimal setup required for running the integration test suite of scc.

/cc @hflynn, @mtbc
