### PR TITLE
Fix SandboxTest.setUp() in case gh.git_repo() fails with a server error

### DIFF
--- a/test/integration/Sandbox.py
+++ b/test/integration/Sandbox.py
@@ -47,7 +47,11 @@ class SandboxTest(unittest.TestCase):
             self.assertEquals(0, p.wait())
             self.sandbox = self.gh.git_repo(self.path)
         except:
-            shutil.rmtree(self.path)
+            try:
+                shutil.rmtree(self.path)
+            finally:
+                # Return to cwd regardless.
+                os.chdir(self.cwd)
             raise
         # If we succeed, then we change to this dir.
         os.chdir(self.path)


### PR DESCRIPTION
If `gh.git_repo()` fails due to e.g. a server error, this commit ensures we return to the initial folder instead of staying in a deleted folder

To test this PR:
see http://hudson.openmicroscopy.org.uk/view/Failing/job/SCC-self-merge/142/console
we shouldn't get any

```
======================================================================
ERROR: testDeployInitBrokenSymlink (test.unit.TestDeploy.TestDeploy)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/omero/slave/workspace/SCC-self-merge/snoopycrimecop/test/unit/TestDeploy.py", line 33, in setUp
    self.folder = os.path.abspath("deploy_test")
  File "/home/omero/slave/workspace/SCC-self-merge/virtualenv/lib/python2.6/posixpath.py", line 343, in abspath
    cwd = os.getcwd()
OSError: [Errno 2] No such file or directory

```

error if SandboxTest.setUp()` fails
