### PR TITLE
Add decorator for GH API calls retries

### DIFF
--- a/scc/git.py
+++ b/scc/git.py
@@ -233,6 +233,7 @@ class GHManager(object):
     def get_organization(self, *args):
         return self.github.get_organization(*args)
 
+    @retry_on_error(retries=3)
     def create_instance(self, *args, **kwargs):
         """
         Subclasses can override this method in order


### PR DESCRIPTION
Recent usages of scc have been failing with github.GithubException 502 Server
Error. This commit adds a decorator implementing retries if a server error is
thrown. Fixes #114.
