### PR TITLE
More robust exception handling in main() entry point

### DIFF
--- a/scc/main.py
+++ b/scc/main.py
@@ -25,6 +25,7 @@ which are present in the globals() of this module
 will be presented to the user.
 """
 
+import traceback
 import sys
 
 from framework import main, Stop
@@ -60,6 +61,9 @@ def entry_point():
     except Stop, stop:
         print stop,
         sys.exit(stop.rc)
+    except:
+        traceback.print_exc()
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In some conditions we have noticed that not exiting explicitly and
allowing an Exception to bubble up causes the setuptools based command
line scripts to hang.  This commit ensures that the entry point never
allows an exception to bubble up beyond its scope.

/cc @joshmoore
