### PR TITLE
Handle SystemExit in main.py

### DIFF
--- a/scc/main.py
+++ b/scc/main.py
@@ -61,7 +61,7 @@ def entry_point():
     except Stop, stop:
         print stop,
         sys.exit(stop.rc)
-    except SystemExit, s:
+    except SystemExit:
         raise
     except:
         traceback.print_exc()


### PR DESCRIPTION
Following changes introduced in #120, a traceback was printed when `SystemExit` was called, e.g.

```
sebastien@sbesson:snoopycrimecop (master) $ scc -h
usage: scc [-h]

           {already-merged,check-milestone,check-status,deploy,label,merge,rebase,set-commit-status,tag-release,token,travis-merge,unrebased-prs,update-submodules,version}
           ...

Snoopy Crime Cop Script

optional arguments:
  -h, --help                            show this help message and exit

Subcommands:
  {already-merged,check-milestone,check-status,deploy,label,merge,rebase,set-commit-status,tag-release,token,travis-merge,unrebased-prs,update-submodules,version}
    already-merged                      Detect branches local & remote which are already merged
    check-milestone                     Check all merged PRs for a set milestone
    check-status                        Check GitHub API status
    deploy                              Deploy an update to a website using the "symlink swapping" strategy.
    label                               Query/add/remove labels from GitHub issues.
    merge                               Merge Pull Requests opened against a specific base branch.
    rebase                              Rebase Pull Requests opened against a specific base branch.
    set-commit-status                   Set commit status on all pull requests with any of the given labels.
    tag-release                         Tag a release recursively across submodules.
    token                               Utility functions to manipulate local and remote GitHub tokens
    travis-merge                        Update submodules and merge Pull Requests in Travis CI jobs.
    unrebased-prs                       Check that PRs in one branch have been merged to another.
    update-submodules                   Similar to the 'merge' command, but only updates submodule pointers.
    version                             Find which version of scc is being used
Traceback (most recent call last):
  File "/Users/sebastien/code/ome/snoopycrimecop/scc/main.py", line 59, in entry_point
    (UpdateSubmodules.NAME, UpdateSubmodules),
  File "/Users/sebastien/code/ome/snoopycrimecop/scc/framework.py", line 185, in main
    ns = scc_parser.parse_args(args)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/argparse.py", line 1688, in parse_args
    args, argv = self.parse_known_args(args, namespace)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/argparse.py", line 1720, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/argparse.py", line 1926, in _parse_known_args
    start_index = consume_optional(start_index)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/argparse.py", line 1866, in consume_optional
    take_action(action, args, option_string)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/argparse.py", line 1794, in take_action
    action(self, namespace, argument_values, option_string)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/argparse.py", line 995, in __call__
    parser.exit()
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/argparse.py", line 2335, in exit
    _sys.exit(status)
SystemExit: 0
```

This PR addresses this by catching and rethrowing `SystemExit` exception in `main.py`

/cc @joshmoore, @chris-allan, @manics
