### PR TITLE
Fix whitespace in conflict message.

### DIFF
--- a/scc/git.py
+++ b/scc/git.py
@@ -1136,7 +1136,7 @@ class GitRepository(object):
 
                 msg = "Conflicting PR."
                 if IS_JENKINS_JOB:
-                    msg += " Removed from build [%s#%s](%s). See the" \
+                    msg += "Removed from build [%s#%s](%s). See the " \
                            "[console output](%s) for more details." \
                            % (JOB_NAME, BUILD_NUMBER, BUILD_URL,
                               BUILD_URL + "/consoleText")


### PR DESCRIPTION
This should place a proper space before the `console output` hyperlink in comments added by SCC.
