### PR TITLE
Drop TestGithub from TestConfig integration tests

### DIFF
--- a/test/integration/TestConfig.py
+++ b/test/integration/TestConfig.py
@@ -22,23 +22,8 @@
 import os
 import unittest
 
-from scc.git import get_token_or_user, get_github, Stop
+from scc.git import get_token_or_user
 from Sandbox import SandboxTest
-
-
-class TestGithub(unittest.TestCase):
-
-    def testUserWithoutPassword(self):
-        self.assertRaises(Stop, get_github, "openmicroscopy",
-                          dont_ask=True)
-
-    def testUserWithWrongPassword(self):
-        self.assertRaises(Stop, get_github, "openmicroscopy",
-                          password="bad_password")
-
-    def testUserWithWrongPasswordNoAsk(self):
-        self.assertRaises(Stop, get_github, "openmicroscopy",
-                          password="bad_password", dont_ask=True)
 
 
 class TestConfig(SandboxTest):


### PR DESCRIPTION
These tests apparently caused the GH API to throw a "Maximum number of login attempts exceeded" exception

See http://hudson.openmicroscopy.org.uk/job/SCC-self-merge/169/ to http://hudson.openmicroscopy.org.uk/job/SCC-self-merge/174/.
With this PR merged in, no more Maximum number of login attempts exceeded should be thrown when running the test suite.
