### PR TITLE
Move cd() call to the low-level wrap-call() function

### DIFF
--- a/scc/git.py
+++ b/scc/git.py
@@ -790,7 +790,7 @@ class GitRepository(object):
             os.chdir(directory)
 
     def communicate(self, *command, **kwargs):
-        p = self.wrap_call(subprocess.PIP, *command, **kwargs)
+        p = self.wrap_call(subprocess.PIPE, *command, **kwargs)
         o, e = p.communicate()
         if p.returncode:
             msg = """Failed to run '%s'


### PR DESCRIPTION
This commit implies any GitRepository method using a low-level `git ...`
command does not need to care about moving to the right location.

Closes #118
