### PR TITLE
Allow to pass sign to scc tag-release

### DIFF
--- a/scc/git.py
+++ b/scc/git.py
@@ -909,7 +909,7 @@ class GitRepository(object):
         self.dbg("Committing %s...", msg)
         self.call("git", "commit", "-m", msg)
 
-    def tag(self, tag, message=None, force=False):
+    def tag(self, tag, message=None, force=False, sign=False):
         """Tag the HEAD of the git repository"""
         if message is None:
             message = "Tag with version %s" % tag
@@ -921,10 +921,13 @@ class GitRepository(object):
             raise Stop(22, "%s is not a valid tag name." % tag)
 
         self.dbg("Creating tag %s...", tag)
+        tag_command = ["git", "tag", tag, "-m", message]
         if force:
-            self.call("git", "tag", "-f", tag, "-m", message)
-        else:
-            self.call("git", "tag", tag, "-m", message)
+            tag_command.append("-f")
+        if sign:
+            tag_command.append("-s")
+
+        self.call(*tag_command)
 
     def new_branch(self, name, head="HEAD"):
         self.dbg("New branch %s from %s...", name, head)
@@ -1341,13 +1344,13 @@ class GitRepository(object):
 
         return prefix
 
-    def rtag(self, version, message=None):
+    def rtag(self, version, message=None, sign=False):
         """Recursively tag repositories with a version number."""
 
         msg = ""
         msg += str(self.origin) + "\n"
         tag_prefix = self.get_tag_prefix()
-        self.tag(tag_prefix + version, message)
+        self.tag(tag_prefix + version, message, sign=sign)
         msg += "Created tag %s\n" % (tag_prefix + version)
 
         for submodule_repo in self.submodules:
@@ -3016,7 +3019,10 @@ class TagRelease(_TagCommands):
             help='Tag message')
         self.parser.add_argument(
             '--push', action='store_true',
-            help='Push new tag to GitHub')
+            help='Push new tag(s) to GitHub')
+        self.parser.add_argument(
+            '--sign', '-s', action='store_true',
+            help='Annotate and GPG-sign the tag(s)')
 
     def __call__(self, args):
         super(TagRelease, self).__call__(args)
@@ -3024,7 +3030,8 @@ class TagRelease(_TagCommands):
         if args.message is None:
             args.message = 'Tag version %s' % args.version
 
-        msg = self.main_repo.rtag(args.version, message=args.message)
+        msg = self.main_repo.rtag(args.version, message=args.message,
+                                  sign=args.sign)
 
         for line in msg.split("\n"):
             self.log.info(line)


### PR DESCRIPTION
This PR should allow to tag a release using annotated GPG-sign tags, i.e. the following should ask for a passphrase assuming you have a private key:

```
$ scc tag-release -s VERSION
```

The tag-release integration tests should be unchanged and still passing with this PR merged.
