### PR TITLE
Add simple check for mergeable status in find_candidates()

### DIFF
--- a/scc/git.py
+++ b/scc/git.py
@@ -691,6 +691,10 @@ class GitHubRepository(object):
         for pull in pulls:
             pullrequest = PullRequest(pull)
 
+            if not pullrequest.mergeable:
+                excluded_pulls[pullrequest] = 'not mergeable'
+                continue
+
             if pullrequest.parse(filters["exclude"].get("label"),
                                  whitelist=is_whitelisted_comment):
                 excluded_pulls[pullrequest] = 'exclude comment'


### PR DESCRIPTION
This commit prevent PRs with a non-mergeable state from entering the merging
pool of PRs and improves the specificity of the exclusion comment.

Closes #150
