### PR TITLE
Revert "Add simple check for mergeable status in find_candidates()"

### DIFF
--- a/scc/git.py
+++ b/scc/git.py
@@ -697,10 +697,6 @@ class GitHubRepository(object):
         for pull in pulls:
             pullrequest = PullRequest(pull)
 
-            if not pullrequest.mergeable:
-                excluded_pulls[pullrequest] = 'not mergeable'
-                continue
-
             if pullrequest.parse(filters["exclude"].get("label"),
                                  whitelist=is_whitelisted_comment):
                 excluded_pulls[pullrequest] = 'exclude comment'


### PR DESCRIPTION
This reverts commit 920bb3718a2818bbf9ef86414d45ff343dd94076.

---

Transient error noticed by @mtpc during review of #152 was noticed in http://ci.openmicroscopy.org/job/OMERO-5.0-merge-integration/203/consoleFull again. As this could seriously harm our review workflow esp. close to a release. I propose to revert the commit and re-release a new version of scc.
