### PR TITLE
Fix scc check-prs by using find_branching_point()

### DIFF
--- a/scc/git.py
+++ b/scc/git.py
@@ -1014,7 +1014,7 @@ class GitRepository(object):
     def get_rev_list(self, commit):
         """Return first parent revision list for a given commit"""
         revlist_cmd = lambda x: ["git", "rev-list", "--first-parent", "%s" % x]
-        o, e = self.communicate(*revlist_cmd(commit))
+        o, e = self.communicate(*revlist_cmd(commit), no_wait=True)
         return o.splitlines()
 
     def has_local_changes(self):


### PR DESCRIPTION
This commit addresses a tricky issue where a branch originated from an
ancestor commit is merged simultaneously in the source and target branches.
In that case, `git merge-base` will return this ancestor commit instead of
the true branching point. To fix this, CheckPRs now uses find_branching_point
already used in Rebase().

---

This PR should fix http://ci.openmicroscopy.org/view/Mgmt/job/SCC-check-prs/.
To test this PR in context, run `python scc/main.py check-prs dev_5_0 develop` from openmicroscopy.git and check the output is valid.
