### PR TITLE
Tag release sign

### DIFF
--- a/scc/git.py
+++ b/scc/git.py
@@ -946,9 +946,9 @@ class GitRepository(object):
             tag_command.append("-f")
         if sign:
             tag_command.append("-s")
-             self.dbg("Creating signed tag %s...", tag)
-         else:
-             self.dbg("Creating tag %s...", tag)
+            self.dbg("Creating signed tag %s...", tag)
+        else:
+            self.dbg("Creating tag %s...", tag)
 
         self.call(*tag_command)
 


### PR DESCRIPTION
This PR fixes an issue noticed during 5.0.1 release:

```
python scc/main.py tag-release -s RELEASE
```

should now propagate the signing option to all submodules (while it was previously signing the tag of the top-level repository only).
