### PR TITLE
milestone list formatting

### DIFF
--- a/scc/git.py
+++ b/scc/git.py
@@ -2643,8 +2643,8 @@ class MilestoneCommand(GitRepoCommand):
             return cmp(a, b)
 
     def list(self, args):
-        fmt = "%20s %20s %20s %16s"
-        header = fmt % ("NAME", "CREATED", "DUE", "ISSUES (OPEN/CLOSED)")
+        fmt = "%-20s %-20s %-20s %-16s"
+        header = fmt % ("NAME", "CREATED", "DUE", "ISSUES (CLOSED)")
 
         all_repos = self.init_command(args)
         for repo in all_repos:
@@ -2656,7 +2656,7 @@ class MilestoneCommand(GitRepoCommand):
             for due_on, m in parsed:
                 due = due_on is not None and due_on or ""
                 print fmt % (m.title, m.created_at, due,
-                             "%3s /%3s" % (m.open_issues, m.closed_issues))
+                             "%-3s (%s)" % (m.open_issues, m.closed_issues))
 
     def check_write_permissions(self, repos):
         permissions = [repo.origin.permissions.push for repo in repos]


### PR DESCRIPTION
See discussion in gh-157. Current output should look like: 

```
2014-04-10 09:21:44,792 [scc.mileston] INFO  Repository: openmicroscopy/openmicroscopy
                NAME              CREATED                  DUE   OPEN CLOSED
               5.0.2  2014-04-08 06:54:56  2014-04-30 07:00:00      0      0
               5.0.3  2014-04-08 06:55:44  2014-05-31 07:00:00      0      0
               5.0.4  2014-04-08 06:55:59  2014-06-29 07:00:00      0      0
               5.1.0  2013-12-19 14:41:49                           0     41
2014-04-10 09:21:45,429 [scc.mileston] INFO  Repository: openmicroscopy/bioformats
                NAME              CREATED                  DUE   OPEN CLOSED
               5.1.0  2013-12-19 14:42:19  2014-03-31 07:00:00      0      0
               5.0.2  2014-04-08 06:54:57  2014-04-30 07:00:00      0      0
               5.0.3  2014-04-08 06:55:45  2014-05-31 07:00:00      0      0
               5.0.4  2014-04-08 06:56:00  2014-06-29 07:00:00      0      0
2014-04-10 09:21:46,047 [scc.mileston] INFO  Repository: ome/scripts
                NAME              CREATED                  DUE   OPEN CLOSED
               5.1.0  2013-12-19 14:43:30  2014-03-31 07:00:00      0      0
               5.0.2  2014-04-08 06:54:58  2014-04-30 07:00:00      0      0
               5.0.3  2014-04-08 06:55:46  2014-05-31 07:00:00      0      0
               5.0.4  2014-04-08 06:56:01  2014-06-29 07:00:00      0      0
2014-04-10 09:21:46,661 [scc.mileston] INFO  Repository: openmicroscopy/ome-documentation
                NAME              CREATED                  DUE   OPEN CLOSED
               5.1.0  2013-12-19 14:43:04  2014-03-31 07:00:00      0     17
               5.0.2  2014-04-08 06:54:58  2014-04-30 07:00:00      0      0
               5.0.3  2014-04-08 06:55:46  2014-05-31 07:00:00      0      0
               5.0.4  2014-04-08 06:56:01  2014-06-29 07:00:00      0      0
```

Suggestions welcome.
