### PR TITLE
Teach scc-check milestone to use remote branch as end point

### DIFF
--- a/scc/git.py
+++ b/scc/git.py
@@ -1969,7 +1969,10 @@ Usage:
         # Construct tag 2 and check its validity
         tag2 = repo.get_tag_prefix() + args.release2
         if not repo.has_local_tag(tag2):
-            raise Stop(21, "Tag %s does not exist." % tag2)
+            if not repo.has_remote_branch(args.release2, remote=args.remote):
+                raise Stop(21, "Tag %s does not exist." % tag2)
+            else:
+                tag2 = args.remote + '/' + args.release2
 
         o, e = repo.communicate(
             "git", "log", "--oneline", "--first-parent",


### PR DESCRIPTION
For @hflynn and @joshmoore reviewing pleasure, this commit should enable command as

```
scc check-milestone 5.0.1 dev_5_0 --set 5.0.2
```
