### PR TITLE
Only perform fast_forward if remote branch exists

### DIFF
--- a/scc/git.py
+++ b/scc/git.py
@@ -1418,19 +1418,20 @@ class GitRepository(object):
             self.cd(self.path)
             self.write_directories()
             presha1 = self.get_current_sha1()
-            ff_msg, ff_log = self.fast_forward(filters["base"],
-                                               remote=self.remote)
-            merge_msg += ff_msg
-            # Scan the fast-forward log to produce a digest of the merged PRs
-            if ff_log:
-                merge_msg += "Merged PRs (fast-forward):\n"
-                pattern = r'Merge pull request #(\d+)'
-                for line in ff_log.split('\n'):
-                    s = re.search(pattern, line)
-                    if s is not None:
-                        pr = self.origin.get_pull(int(s.group(1)))
-                        merge_msg += str(PullRequest(pr)) + '\n'
-            merge_msg += '\n'
+            if self.has_remote_branch(filters["base"], self.remote):
+                ff_msg, ff_log = self.fast_forward(filters["base"],
+                                                   remote=self.remote)
+                merge_msg += ff_msg
+                # Scan the ff log to produce a digest of the merged PRs
+                if ff_log:
+                    merge_msg += "Merged PRs (fast-forward):\n"
+                    pattern = r'Merge pull request #(\d+)'
+                    for line in ff_log.split('\n'):
+                        s = re.search(pattern, line)
+                        if s is not None:
+                            pr = self.origin.get_pull(int(s.group(1)))
+                            merge_msg += str(PullRequest(pr)) + '\n'
+                merge_msg += '\n'
 
             merge_msg += self.merge(comment, commit_id=commit_id,
                                     set_commit_status=set_commit_status)


### PR DESCRIPTION
With the last release of `scc` instances of `scc travis-merge` failed with the following error

```
$ scc travis-merge
2014-06-11 11:34:47,575 [scc.travis-m] INFO Merging Pull Request(s) based on dev_5_0
fatal: ambiguous argument 'HEAD..origin/dev_5_0': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
Traceback (most recent call last):
File "/usr/local/lib/python2.7/dist-packages/scc/main.py", line 76, in entry_point
(UpdateSubmodules.NAME, UpdateSubmodules),
File "/usr/local/lib/python2.7/dist-packages/scc/framework.py", line 186, in main
ns.func(ns)
File "/usr/local/lib/python2.7/dist-packages/scc/git.py", line 3159, in __call__
args.info)
File "/usr/local/lib/python2.7/dist-packages/scc/git.py", line 1422, in rmerge
remote=self.remote)
File "/usr/local/lib/python2.7/dist-packages/scc/git.py", line 1102, in fast_forward
raise Exception("%r failed" % ' '.join(args))
Exception: u'git log --oneline --first-parent HEAD..origin/dev_5_0' failed
```

This applied in the case where the PR was opened against the non-default branch since Travis does not fetch this remote branch after cloning the repository. The `origin/branch` reference ended up undefined. This commit fixes this behavior by encapsulating the `fast forward` call in  a conditional `if` statement.
