### PR TITLE
Decorate GitRepository.is_whitelisted() with retry_on_errors

### DIFF
--- a/scc/git.py
+++ b/scc/git.py
@@ -706,6 +706,7 @@ class GitHubRepository(object):
     def get_owner(self):
         return self.owner.login
 
+    @retry_on_error(retries=SCC_RETRIES)
     def is_whitelisted(self, user, whitelist):
 
         if not whitelist:


### PR DESCRIPTION
See:
- http://ci.openmicroscopy.org/view/Failing/job/OMERO-5.0-merge-push/68/console
- http://ci.openmicroscopy.org/view/Failing/job/OMERO-5.1-merge-push/307/console
- http://ci.openmicroscopy.org/view/Docs/job/OMERO-5.1-merge-docs/144/console
- http://ci.openmicroscopy.org/view/Failing/job/BIOFORMATS-5.1-merge-openbytes-performance/166/console
