### PR TITLE
Add final line breaks at the end of each section in the merge log

### DIFF
--- a/scc/git.py
+++ b/scc/git.py
@@ -1351,19 +1351,23 @@ class GitRepository(object):
         if merged_pulls:
             merge_msg += "Merged PRs:\n"
             merge_msg += "\n".join([str(x) for x in merged_pulls])
+            merge_msg += "\n"
 
         if merged_branches:
             merge_msg += "Merged branches:\n"
             merge_msg += "\n".join(["  # %s\n" % x for x in merged_branches])
+            merge_msg += "\n"
 
         if conflicting_pulls:
             merge_msg += "Conflicting PRs (not included):\n"
             merge_msg += "\n".join([str(x) for x in conflicting_pulls])
+            merge_msg += "\n"
 
         if conflicting_branches:
             merge_msg += "Conflicting branches (not included):\n"
             merge_msg += "\n".join(["  # %s\n" % x for x in
                                     conflicting_branches])
+            merge_msg += "\n"
         return merge_msg
 
     def merge_pull(self, pullrequest, comment=False, commit_id="merge"):


### PR DESCRIPTION
Close #178.

As part of #167 refactoring, some trailing linebreaks has been stripped from the log message. This commit should restored these line breaks to separate the merged/conflicting PRs blocks.

/cc @mtbc
