### PR TITLE
Try to fix intermittent SSL error in RebaseTest.has_rebased_pr()

### DIFF
--- a/test/integration/test_rebase.py
+++ b/test/integration/test_rebase.py
@@ -54,9 +54,12 @@ class RebaseTest(SandboxTest):
     def has_rebased_pr(self):
 
         # Check the last opened PR is the rebased one
-        prs = self.sandbox.origin.get_pulls()
-        return prs[0].head.user.login == self.user and \
-            prs[0].head.ref == self.target_branch
+        pulls = self.sandbox.origin.get_pulls()
+        for pull in pulls:
+            if pull.head.user.login == self.user and \
+                    pull.head.ref == self.target_branch:
+                return True
+        return False
 
     def teardown_method(self, method):
 


### PR DESCRIPTION
Attempt to fix intermittent SSLerror like http://ci.openmicroscopy.org/view/Failing/job/SCC-merge/378/console. Alternatively, we could extend `GithubRepository.get_pulls()` to allow a `filter` argument which would make it inherit the `retry_on_error` decoration.
