### PR TITLE
scc check-prs caching

### DIFF
--- a/scc/git.py
+++ b/scc/git.py
@@ -2233,7 +2233,8 @@ command.
 
                 for key in m.keys():
                     comments = ", ".join(['--rebased'+x for x in m[key]])
-                    self.rebasedprs.remove(key)
+                    if key in self.rebasedprs:
+                        self.rebasedprs.remove(key)
                     print "  # PR %s: expected '%s' comment(s)" %  \
                         (key, comments)
                 mismatch_count = len(m.keys())


### PR DESCRIPTION
This PR should implement some minimal caching mechanism for `scc check-prs`:
- creates new attribute`rebasedprs`, i.e. a set of all merged PRs rebased to another merged PR with matching links
- stores all the `links` to the `rebasedprs` set to a cache file using `pickle.dump`
- reloads the stored links from the cache file and updates `self.links` and `self.rebasedprs`
- cleans deprecated code using `git notes` in favor of this mechanism

Notes about PR caching:
- most rebased PRs should be skipped from the rebase check which should save time and API calls
- all unrebased PRs, non-rebase PRs, opened PRs and  PRs with mismatching comments will be rechecked 
- the cache should be updated every time the job is run if the same `cachedir` is used

To test this PR:
1. from a repository with multiple branches (e.g. ome-release), run the `scc check-prs` command in verbose mode, 
   
   ```
   python path/to/scc/main.py check-prs dev_5_0 develop --cache-dir /tmp -v
   ```
2. check all PRs are visited in the log
3. re-run the same command, only non-rebase, open or mismatching PRs should now be checked and the command should complete much faster overall
