### PR TITLE
Comment on possible conflicts

### DIFF
--- a/scc/git.py
+++ b/scc/git.py
@@ -1474,8 +1474,12 @@ class GitRepository(object):
 
     def get_conflicts_message(self, conflicts, upstream_conflicts):
         conflict_msg = ''
-        if conflicts:
+        if conflicts or upstream_conflicts:
             conflict_msg += '\nPossible conflicts:'
+        else:
+            conflict_msg += '\nFailed to autodetect conflicts'
+
+        if conflicts:
             for pr in sorted(
                     conflicts.keys(), key=lambda c: c.get_number()):
                 conflict_msg += "\n  - PR #%d %s '%s'\n%s" % (
@@ -1484,8 +1488,6 @@ class GitRepository(object):
         if upstream_conflicts:
             conflict_msg += '\n  - Upstream changes\n' + \
                 '\n'.join('    - %s' % f for f in upstream_conflicts)
-        if not conflicts and not upstream_conflicts:
-            conflict_msg += '\n  - Failed to autodetect conflicts'
         return conflict_msg
 
     def merge_pull(self, pullrequest, comment=False, commit_id="merge",

--- a/scc/git.py
+++ b/scc/git.py
@@ -926,7 +926,7 @@ class GitHubRepository(object):
             return
 
         # Check for repositories in include
-        forks = [f for f in filters["include"] if '/' in f]
+        forks = [f for f in filters["include"] if re.match('.+/.+:.+', f)]
         for fork in forks:
             remote = fork.split('/')[0]
             self.candidate_branches[remote] = (

--- a/scc/git.py
+++ b/scc/git.py
@@ -1348,7 +1348,8 @@ class GitRepository(object):
         files = set(files.split("\n")[:-1])
         return files
 
-    def get_possible_conflicts(self, pull, conflict_files, changed_files, upstream):
+    def get_possible_conflicts(
+            self, pull, conflict_files, changed_files, upstream):
         """
         Find possible conflicting pull requests by finding other pull requests
         which modify the same file.

--- a/scc/git.py
+++ b/scc/git.py
@@ -1336,6 +1336,8 @@ class GitRepository(object):
 
         changed_files: A dictionary of (PullRequest, [changed-filenames])
         """
+        if not changed_files:
+            return {}
         pull_changed = changed_files[pull]
         conflicts = {}
         for (pr, changed) in changed_files.iteritems():
@@ -1463,19 +1465,17 @@ class GitRepository(object):
                 "[console output](%s) for more details." \
                 % (JOB_NAME, BUILD_NUMBER, BUILD_URL,
                    BUILD_URL + "consoleText")
-        if all_changed_files:
-            conflicts = self.get_possible_conflicts(
-                pullrequest, all_changed_files)
-            if conflicts:
-                conflict_msg += '\nPossible conflicts:'
-                for pr in sorted(
-                        conflicts.keys(), key=lambda c: c.get_number()):
-                    conflict_msg += '\n  - #%d %s' % (pr.get_number(), pr)
-                    for file in sorted(conflicts[pr]):
-                        conflict_msg += '\n    - %s' % file
-            else:
-                conflict_msg += (
-                    '\n  - No conflicts found, you may need to rebase')
+        conflicts = self.get_possible_conflicts(pullrequest, all_changed_files)
+        if conflicts:
+            conflict_msg += '\nPossible conflicts:'
+            for pr in sorted(
+                    conflicts.keys(), key=lambda c: c.get_number()):
+                conflict_msg += '\n  - #%d %s' % (pr.get_number(), pr)
+                for file in sorted(conflicts[pr]):
+                    conflict_msg += '\n    - %s' % file
+        else:
+            conflict_msg += (
+                '\n  - No conflicts found, you may need to rebase')
 
         self.dbg(conflict_msg)
 

--- a/scc/git.py
+++ b/scc/git.py
@@ -1501,7 +1501,8 @@ class GitRepository(object):
             conflict_msg += '\nPossible conflicts:'
             for pr in sorted(
                     conflicts.keys(), key=lambda c: c.get_number()):
-                conflict_msg += '\n  - #%d %s' % (pr.get_number(), pr)
+                conflict_msg += "\n  - PR #%d %s '%s'" % (
+                    pr.get_number(), pr.get_login(), pr.get_title())
                 for file in sorted(conflicts[pr]):
                     conflict_msg += '\n    - %s' % file
         if upstream_conflicts:
@@ -1511,7 +1512,7 @@ class GitRepository(object):
         if not conflicts and not upstream_conflicts:
             conflict_msg += ('\n  - Failed to autodetect conflicts')
 
-        self.dbg(conflict_msg)
+        self.dbg('%s\n%s', pullrequest, conflict_msg)
 
         if comment and get_token():
             self.dbg("Adding comment to issue #%g." %

--- a/scc/git.py
+++ b/scc/git.py
@@ -1378,9 +1378,7 @@ class GitRepository(object):
 
     def safe_merge(self, sha, message):
         """Merge a branch and revert to current HEAD in case of conflict."""
-        premerge_sha, e = self.call("git", "rev-parse", "HEAD",
-                                    stdout=subprocess.PIPE).communicate()
-        premerge_sha = premerge_sha.rstrip("\n")
+        premerge_sha = self.get_current_sha1()
 
         try:
             self.call("git", "merge", "--no-ff", "-m", message, sha)

--- a/scc/git.py
+++ b/scc/git.py
@@ -1464,13 +1464,18 @@ class GitRepository(object):
                 % (JOB_NAME, BUILD_NUMBER, BUILD_URL,
                    BUILD_URL + "consoleText")
         if all_changed_files:
-            conflict_msg += '\n Possible conflicts:'
             conflicts = self.get_possible_conflicts(
                 pullrequest, all_changed_files)
-            for pr in sorted(conflicts.keys(), key=lambda c: c.get_number()):
-                conflict_msg += '\n  - #%d %s' % (pr.get_number(), pr)
-                for file in sorted(conflicts[pr]):
-                    conflict_msg += '\n    - %s' % file
+            if conflicts:
+                conflict_msg += '\nPossible conflicts:'
+                for pr in sorted(
+                        conflicts.keys(), key=lambda c: c.get_number()):
+                    conflict_msg += '\n  - #%d %s' % (pr.get_number(), pr)
+                    for file in sorted(conflicts[pr]):
+                        conflict_msg += '\n    - %s' % file
+            else:
+                conflict_msg += (
+                    '\n  - No conflicts found, you may need to rebase')
 
         self.dbg(conflict_msg)
 

--- a/scc/git.py
+++ b/scc/git.py
@@ -868,7 +868,7 @@ class GitHubRepository(object):
         pr_attributes["label"] = [x.lower() for x in
                                   pullrequest.get_labels()]
         pr_attributes["user"] = [pullrequest_user.login]
-        pr_attributes["pr"] = [str(pullrequest.get_number())]
+        pr_attributes["pr"] = ['#' + str(pullrequest.get_number())]
 
         if not self.is_whitelisted(pullrequest_user,
                                    filters["include"].get("user")):
@@ -930,7 +930,8 @@ class GitHubRepository(object):
         for fork in forks:
             remote = fork.split('/')[0]
             self.candidate_branches[remote] = (
-                self.gh.get_repo(fork), filters["include"][fork])
+                self.gh.get_repo(fork), [b for b in filters["include"][fork]
+                                         if not re.match('#\d+$', b)])
 
 
 class GitRepository(object):
@@ -2130,6 +2131,8 @@ ALL sets user:#all as the default include filter. Default: ORG.""")
 
         key = m.group('key')
         value = m.group('value')
+        if key == 'pr':
+            value = '#' + value
         self.filters[ftype].setdefault(key, []).append(value)
         return True
 
@@ -2145,7 +2148,7 @@ ALL sets user:#all as the default include filter. Default: ORG.""")
             prefix = 'pr'
         else:
             prefix = m.group('prefix')
-        self.filters[ftype].setdefault(prefix, []).append(m.group('nr'))
+        self.filters[ftype].setdefault(prefix, []).append('#' + m.group('nr'))
         return True
 
     def _parse_url(self, ftype, value):
@@ -2158,7 +2161,7 @@ ALL sets user:#all as the default include filter. Default: ORG.""")
             return False
 
         prefix = m.group('prefix')
-        self.filters[ftype].setdefault(prefix, []).append(m.group('nr'))
+        self.filters[ftype].setdefault(prefix, []).append('#' + m.group('nr'))
         return True
 
 

--- a/scc/git.py
+++ b/scc/git.py
@@ -1377,17 +1377,6 @@ class GitRepository(object):
             files = self.list_merged_files(pullrequest.get_sha())
             changed_files[pullrequest] = files
 
-        self.dbg('Possible conflicts:')
-        for pull in self.origin.candidate_pulls:
-            conflicts = self.get_possible_conflicts(pull, changed_files)
-            if conflicts:
-                self.dbg('  %s may conflict with:' % pull)
-                for pr in sorted(
-                        conflicts.keys(), key=lambda c: c.get_number()):
-                    self.dbg('    %s' % pr)
-                    for file in sorted(conflicts[pr]):
-                        self.dbg('        %s' % file)
-
         for pullrequest in self.origin.candidate_pulls:
             merge_status = self.merge_pull(
                 pullrequest, comment=comment, commit_id=commit_id,

--- a/scc/git.py
+++ b/scc/git.py
@@ -1317,12 +1317,12 @@ class GitRepository(object):
             repo = basename.rsplit()[0]
         return [user, repo]
 
-    def list_merged_files(self, sha):
+    def list_merged_files(self, sha, upstream="HEAD"):
         """
         Return a list of files modified by this PR
         """
         p = self.call(
-            "git", "diff", "--name-only", "HEAD...%s" % sha,
+            "git", "diff", "--name-only", "%s...%s" % (upstream, sha),
             stdout=subprocess.PIPE)
         files = p.communicate()[0]
         p.stdout.close()
@@ -1404,10 +1404,12 @@ class GitRepository(object):
         merged_branches = []
 
         for pullrequest in self.origin.candidate_pulls:
+            # Compare current PR against the list of PRs merged so far
+            # (An alternative would be to compare against pre-merge by
+            # passing upstream_sha as the second of list_merged_files)
             files = self.list_merged_files(pullrequest.get_sha())
             changed_files[pullrequest] = files
 
-        for pullrequest in self.origin.candidate_pulls:
             merge_status = self.merge_pull(
                 pullrequest, comment=comment, commit_id=commit_id,
                 all_changed_files=changed_files, upstream=upstream_sha)

--- a/scc/git.py
+++ b/scc/git.py
@@ -928,7 +928,7 @@ class GitHubRepository(object):
         # Check for repositories in include
         forks = [f for f in filters["include"] if '/' in f]
         for fork in forks:
-            remote = re.sub('/%s$' % self.repo_name, '', fork)
+            remote = fork.split('/')[0]
             self.candidate_branches[remote] = (
                 self.gh.get_repo(fork), filters["include"][fork])
 

--- a/scc/git.py
+++ b/scc/git.py
@@ -1363,10 +1363,10 @@ class GitRepository(object):
         if not changed_files:
             return conflicts, upstream_conflicts
 
-        pull_changed = []
+        pull_changed = set()
         for cf in conflict_files:
             if cf in changed_files[pull]:
-                pull_changed.append(cf)
+                pull_changed.add(cf)
             else:
                 # Uncommitted changes in working directory
                 try:
@@ -1403,6 +1403,7 @@ class GitRepository(object):
                 conflicts, e = self.call(
                     "git", "diff", "--name-only", "--diff-filter=u",
                     stdout=subprocess.PIPE).communicate()
+                conflicts = [c for c in conflicts.split('\n') if c]
                 return conflicts
             finally:
                 self.call("git", "reset", "--hard", "%s" % premerge_sha)

--- a/scc/git.py
+++ b/scc/git.py
@@ -1468,7 +1468,7 @@ class GitRepository(object):
             conflicts = self.get_possible_conflicts(
                 pullrequest, all_changed_files)
             for pr in sorted(conflicts.keys(), key=lambda c: c.get_number()):
-                conflict_msg += '\n  - %s #%d' % (pr, pr.get_number())
+                conflict_msg += '\n  - #%d %s' % (pr.get_number(), pr)
                 for file in sorted(conflicts[pr]):
                     conflict_msg += '\n    - %s' % file
 

--- a/scc/git.py
+++ b/scc/git.py
@@ -926,7 +926,7 @@ class GitHubRepository(object):
             return
 
         # Check for repositories in include
-        forks = [f for f in filters["include"] if re.match('.+/.+:.+', f)]
+        forks = [f for f in filters["include"] if '/' in f]
         for fork in forks:
             remote = fork.split('/')[0]
             self.candidate_branches[remote] = (

--- a/test/integration/Sandbox.py
+++ b/test/integration/Sandbox.py
@@ -93,22 +93,28 @@ class SandboxTest(object):
         name = os.path.join(self.path, self.uuid())
         return open(name, "w")
 
-    def fake_branch(self, head="master"):
+    def fake_branch(self, head="master", commits=None):
         """
-        Return a local branch with a single commit adding a unique file
+        Return a local branch with a list of commits, defaults to a single
+        commit adding a unique file
         """
 
-        with self.unique_file() as f:
-            f.write("hi")
-
-        path = f.name
-        name = f.name.split(os.path.sep)[-1]
+        name = self.uuid()
+        if commits is None:
+            commits = [(os.path.join(self.path, name), "hi")]
+            with self.unique_file() as f:
+                f.write("hi")
 
         self.sandbox.new_branch(name, head=head)
-        self.sandbox.add(path)
 
-        self.sandbox.commit("Writing %s" % name)
-        self.sandbox.get_status()
+        for n in xrange(len(commits)):
+            fname, txt = commits[n]
+            with open(fname, 'w') as f:
+                f.write(txt)
+            self.sandbox.add(fname)
+            self.sandbox.commit("%d: Writing %s" % (n, fname))
+            self.sandbox.get_status()
+
         return name
 
     def add_remote(self):

--- a/test/integration/Sandbox.py
+++ b/test/integration/Sandbox.py
@@ -84,15 +84,6 @@ class SandboxTest(object):
         """
         return str(uuid.uuid4())
 
-    def unique_file(self):
-        """
-        Call open() with a unique file name
-        and "w" for writing
-        """
-
-        name = os.path.join(self.path, self.uuid())
-        return open(name, "w")
-
     def fake_branch(self, head="master", commits=None):
         """
         Return a local branch with a list of commits, defaults to a single
@@ -101,14 +92,13 @@ class SandboxTest(object):
 
         name = self.uuid()
         if commits is None:
-            commits = [(os.path.join(self.path, name), "hi")]
-            with self.unique_file() as f:
-                f.write("hi")
+            commits = [(name, "hi")]
 
         self.sandbox.new_branch(name, head=head)
 
         for n in xrange(len(commits)):
             fname, txt = commits[n]
+            fname = os.path.join(self.path, fname)
             with open(fname, 'w') as f:
                 f.write(txt)
             self.sandbox.add(fname)

--- a/test/integration/Sandbox.py
+++ b/test/integration/Sandbox.py
@@ -102,7 +102,7 @@ class SandboxTest(object):
             with open(fname, 'w') as f:
                 f.write(txt)
             self.sandbox.add(fname)
-            self.sandbox.commit("%d: Writing %s" % (n, fname))
+            self.sandbox.commit("%d: Writing %s" % (n, name))
             self.sandbox.get_status()
 
         return name

--- a/test/integration/test_merge.py
+++ b/test/integration/test_merge.py
@@ -164,6 +164,9 @@ class TestMergePullRequest(MergeTest):
         comments = issue.get_comments()
         assert comments[0].body == EMPTY_MSG
 
+    def testListMergedFiles(self):
+        assert self.sandbox.list_merged_files(self.sha) == {self.branch}
+
 
 class TestMergeBranch(MergeTest):
 

--- a/test/integration/test_merge.py
+++ b/test/integration/test_merge.py
@@ -167,6 +167,12 @@ class TestMergePullRequest(MergeTest):
     def testListMergedFiles(self):
         assert self.sandbox.list_merged_files(self.sha) == set([self.branch])
 
+    def testListUpstreamChanges(self):
+        assert self.sandbox.list_upstream_changes(self.sha) == set()
+        upstream = self.fake_branch(head=self.base)
+        assert self.sandbox.list_upstream_changes(self.sha, upstream) == set(
+            [upstream])
+
 
 class TestMergeBranch(MergeTest):
 

--- a/test/integration/test_merge.py
+++ b/test/integration/test_merge.py
@@ -165,7 +165,7 @@ class TestMergePullRequest(MergeTest):
         assert comments[0].body == EMPTY_MSG
 
     def testListMergedFiles(self):
-        assert self.sandbox.list_merged_files(self.sha) == {self.branch}
+        assert self.sandbox.list_merged_files(self.sha) == set([self.branch])
 
 
 class TestMergeBranch(MergeTest):

--- a/test/unit/test_filters.py
+++ b/test/unit/test_filters.py
@@ -63,8 +63,8 @@ class TestFilter(MockTest):
     def testStatus(self, labels, users, prs):
         self.filters = {"label": labels, "user": users, "pr": prs}
         status, reason = self.run_filter()
-        assert status is ("test_label" in labels) or ("test_user" in users) \
-            or ("1" in prs)
+        assert status is (("test_label" in labels) or ("test_user" in users)
+                          or ("1" in prs))
 
 
 class TestFilteredPullRequestsCommand(MoxTestBase):


### PR DESCRIPTION
Replaces #186 

`git diff --name-only --diff-filter=u` is now used to find conflicting files after a failed merged.

Note f516594ec568c387225222ce258350d33b77090c adds additional checks before merging branches:
- Branch must exist (without this check non-existent branches are ignored without warning)
- Branch must share a parent commit (closes #194 )
