### PR TITLE
Modify setup.py usage in Python testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 before_script:
   - python scc/main.py travis-merge
 script:
-  - python setup.py test -s test/unit -v
+  - python setup.py test -t test/unit -v
   - python setup.py sdist install
   - pip install dist/*.tar.gz
   - scc version

--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ Unit tests
 
 Unit tests are stored under the `test/unit` folder and can be run by calling::
 
-  python setup.py test -s test/unit
+  python setup.py test -t test/unit
 
 Unit tests are also run by the Travis_ build on every Pull Request opened
 against the main repository.

--- a/setup.py
+++ b/setup.py
@@ -30,18 +30,18 @@ import sys
 
 
 class PyTest(TestCommand):
-    user_options = TestCommand.user_options + \
-        [('test-pythonpath=', 'p', "prepend 'pythonpath' to PYTHONPATH"),
-         ('test-string=', 'k', "only run tests including 'string'"),
-         ('test-marker=', 'm', "only run tests including 'marker'"),
-         ('test-path=', 's', "base dir for test collection"),
-         ('test-failfast', 'x', "Exit on first error"),
-         ('test-verbose', 'v', "more verbose output"),
-         ('test-quiet', 'q', "less verbose output"),
-         ('test-no-capture', 'c', "equivalent to PyTest --capture=no"),
-         ('junitxml=', None, "create junit-xml style report file at 'path'"),
-         ('pdb', None, "fallback to pdb on error"),
-         ]
+    user_options = [
+        ('test-path=', 't', "base dir for test collection"),
+        ('test-pythonpath=', 'p', "prepend 'pythonpath' to PYTHONPATH"),
+        ('test-string=', 'k', "only run tests including 'string'"),
+        ('test-marker=', 'm', "only run tests including 'marker'"),
+        ('test-no-capture', 's', "don't suppress test output"),
+        ('test-failfast', 'x', "Exit on first error"),
+        ('test-verbose', 'v', "more verbose output"),
+        ('test-quiet', 'q', "less verbose output"),
+        ('junitxml=', None, "create junit-xml style report file at 'path'"),
+        ('pdb', None, "fallback to pdb on error"),
+        ]
 
     def initialize_options(self):
         TestCommand.initialize_options(self)


### PR DESCRIPTION
See also https://github.com/openmicroscopy/openmicroscopy/pull/3319

The following commands should work:
- ` ./setup.py test -t <path to tests>` should run a folder of tests
- `./setup.py test -t <path to tests> -s` should run a folder of tests and output any stdout with the tests to the console.

/cc @manics