### PR TITLE
Raise exception if git merge-base returns nothing

### DIFF
--- a/scc/git.py
+++ b/scc/git.py
@@ -1261,7 +1261,12 @@ class GitRepository(object):
     def merge_base(self, a, b):
         """Return the first ancestor between two branches"""
 
-        mrg = self.communicate("git", "merge-base", a, b)
+        try:
+            mrg = self.communicate("git", "merge-base", a, b)
+        except Exception as e:
+            self.log.error(e)
+            raise Exception(
+                'Failed to find common ancestor of %s and %s' % (a, b))
         return mrg.strip()
 
     def list_remotes(self):

--- a/scc/git.py
+++ b/scc/git.py
@@ -1332,8 +1332,8 @@ class GitRepository(object):
         Return a list of files modified in parent since this PR was branched,
         suggesting a rebase may be necessary.
         """
-        files = self.communicate("git", "merge-base", upstream, sha)
-        common_base = files.split("\n")[0]
+        mrg = self.merge_base(upstream, sha)
+        common_base = mrg.split("\n")[0]
 
         files = self.communicate(
             "git", "diff", "--name-only", "%s..%s" % (common_base, upstream))
@@ -2718,7 +2718,7 @@ class AlreadyMerged(GitHubCommand):
         parts = input.split(" ")
         branch = parts[3]
         tip = main_repo.communicate("git", "rev-parse", branch)
-        mrg = main_repo.communicate("git", "merge-base", branch, target)
+        mrg = main_repo.merge_base(branch, target)
         if tip == mrg:
             print input
 


### PR DESCRIPTION
A corner case, but should help if a similar situation to https://trello.com/c/QKJKaCHL/260-pr-merge-against-non-latest-homebrew-tap-fails arises in future.

To test:
- `git clone --depth=-1` a repository with open PRs (I think the PRs may need to be opened against a commit older than HEAD).
- scc merge master

You should see an exception along the lines of `Exception: Failed to find common ancestor of 52dcc56ba0155cfb10378134b9e882204d78590a and 4c77ae868536a4e614be9fbaa39c90a0df82845e`

Note I haven't bothered to make this look nice because it's a corner case, and it's mostly to help with diagnosing the underlying problem.