### PR TITLE
Always push the branch in the Merge command

### DIFF
--- a/scc/git.py
+++ b/scc/git.py
@@ -2908,7 +2908,7 @@ class Merge(FilteredPullRequestsCommand):
                 self.log.debug("Cleaning remote branches created for merging")
                 self.main_repo.rcleanup()
 
-        if updated and args.push is not None:
+        if args.push is not None:
             self.push(args, self.main_repo)
 
     def merge(self, args, main_repo):

--- a/scc/git.py
+++ b/scc/git.py
@@ -2902,7 +2902,7 @@ class Merge(FilteredPullRequestsCommand):
         self.init_main_repo(args)
 
         try:
-            updated = self.merge(args, self.main_repo)
+            self.merge(args, self.main_repo)
         finally:
             if not args.info:
                 self.log.debug("Cleaning remote branches created for merging")


### PR DESCRIPTION
The current design was implemented for repositories with lots of open requests
in mind so that the merge branch is always updated. However, for repositories
or development branches with few PRs opened, the requirement can mean the
merge branch never gets updated to the HEAD of the development branch if all
PRs are closed or excluded.

This commit removes this restriction by pushing unconditionally the merge
branch when the --push argument is passed.

/cc @joshmoore 