### PR TITLE
Allow to pass the PR description to Sandbox.open_pr()

### DIFF
--- a/scc/git.py
+++ b/scc/git.py
@@ -856,8 +856,8 @@ class GitHubRepository(object):
 
     def filter_pull(self, pullrequest, filters):
 
-        is_whitelisted_comment = lambda x: self.is_whitelisted(
-            x.user, filters["include"].get("user"))
+        def is_whitelisted_comment(x):
+            return self.is_whitelisted(x.user, filters["include"].get("user"))
 
         if pullrequest.parse(filters["exclude"].get("label"),
                              whitelist=is_whitelisted_comment):
@@ -1185,8 +1185,8 @@ class GitRepository(object):
 
     def get_rev_list(self, commit):
         """Return first parent revision list for a given commit"""
-        revlist_cmd = lambda x: ["git", "rev-list", "--first-parent", "%s" % x]
-        o = self.communicate(*revlist_cmd(commit))
+        args = ["git", "rev-list", "--first-parent", "%s" % commit]
+        o = self.communicate(*args)
         return o.splitlines()
 
     def has_local_changes(self):

--- a/test/integration/Sandbox.py
+++ b/test/integration/Sandbox.py
@@ -131,15 +131,18 @@ class SandboxTest(object):
         self.add_remote()
         self.sandbox.push_branch(branch, remote=self.user)
 
-    def open_pr(self, branch, base):
+    def open_pr(self, branch, base, description=None):
         """
         Push a local branch and open a PR against the selected base
         """
         self.push_branch(branch)
+        if description is None:
+            description = ("This is a call to Sandbox.open_pr by %s" %
+                           self.method)
+
         new_pr = self.sandbox.origin.open_pr(
             title="test %s" % branch,
-            description="This is a call to Sandbox.open_pr by %s"
-            % self.method,
+            description=description,
             base=base,
             head="%s:%s" % (self.user, branch))
 

--- a/test/integration/test_merge.py
+++ b/test/integration/test_merge.py
@@ -157,7 +157,8 @@ class TestMergePullRequest(MergeTest):
 
     def testEmptyDescription(self):
 
-        self.pr.edit(body='')
+        self.pr.edit(state="closed")
+        self.pr = self.open_pr(self.branch, self.base, description="")
         self.merge('--comment')
         assert self.isMerged()
         issue = self.sandbox.origin.get_issue(self.pr.number)

--- a/test/unit/test_filters.py
+++ b/test/unit/test_filters.py
@@ -63,8 +63,8 @@ class TestFilter(MockTest):
     def testStatus(self, labels, users, prs):
         self.filters = {"label": labels, "user": users, "pr": prs}
         status, reason = self.run_filter()
-        assert status is (("test_label" in labels) or ("test_user" in users)
-                          or ("#1" in prs))
+        assert status is (("test_label" in labels) or ("test_user" in users) or
+                          ("#1" in prs))
 
 
 class TestFilteredPullRequestsCommand(MoxTestBase):

--- a/test/unit/test_pullrequest.py
+++ b/test/unit/test_pullrequest.py
@@ -195,8 +195,10 @@ class TestPullRequest(MoxTestBase):
                 comments.append("mock-comment-%s" % is_org_user)
 
         self.mox.ReplayAll()
-        whitelist = lambda x: org.has_in_public_members(x.user)
-        assert self.pr.get_comments(whitelist=whitelist) == comments
+
+        def org_whitelist(x):
+            return org.has_in_public_members(x.user)
+        assert self.pr.get_comments(whitelist=org_whitelist) == comments
 
     def test_create_issue_comment(self):
         comment = self.mox.CreateMock(IssueComment)


### PR DESCRIPTION
This commit fixes a regression observed in the recent integration tests where
editing a Pull Request body with an empty string seems to be a no-op. Instead,
the Sandbox method signature is modified to pass the content of the PR body and
the test first closes the existing PR and reopens a new one with an empty
description before testing the comment logic while running the merge command.

Fixes https://github.com/openmicroscopy/snoopycrimecop/issues/208