### PR TITLE
Add Pypi badge and fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 
+python: 2.7
+
 # This (sudo: false) is needed to "run on container-based infrastructure" on
 # which cache: is available
 # http://docs.travis-ci.com/user/workers/container-based-infrastructure/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: python
 
-python:
-  - "2.6"
-  - "2.7"
-
 # This (sudo: false) is needed to "run on container-based infrastructure" on
 # which cache: is available
 # http://docs.travis-ci.com/user/workers/container-based-infrastructure/
@@ -14,7 +10,6 @@ cache: pip
 before_install:
   - pip install -r requirements.txt
   - pip install flake8
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install argparse; fi
 
 before_script:
   - flake8 -v .

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,7 @@ Snoopy Crime Copy (SCC)
 =======================
 
 |Build Status|
+|Pypi|
 
 Introduction
 ------------
@@ -117,3 +118,6 @@ Copyright
 
 .. |Build Status| image:: https://travis-ci.org/openmicroscopy/snoopycrimecop.png
    :target: http://travis-ci.org/openmicroscopy/snoopycrimecop
+
+.. |Pypi| image:: https://badge.fury.io/py/scc.svg
+    :target: https://badge.fury.io/py/scc

--- a/README.rst
+++ b/README.rst
@@ -105,7 +105,7 @@ snoopycrimecop is released under the GPL.
 Copyright
 ---------
 
-2012-2013, The Open Microscopy Environment
+2012-2016, The Open Microscopy Environment
 
 .. _SCC-self-merge: http://hudson.openmicroscopy.org.uk/view/Mgmt/job/SCC-self-merge/
 .. _PyGithub: https://github.com/jacquev6/PyGithub


### PR DESCRIPTION
This PR:

- adds a badge to the top-level README linking to the Pypi distribution of scc
- removes Python 2.6 from the Travis matrix build to fix the build with flake8 3+