### PR TITLE
Improve tracking branch filter parsing

### DIFF
--- a/scc/git.py
+++ b/scc/git.py
@@ -2136,7 +2136,7 @@ ALL sets user:#all as the default include filter. Default: ORG.""")
         """Parse a key/value pattern of type key/value"""
         keyvalue_pattern = r'(?P<key>([\w-]+)(/[\w-]+)?)' + \
             r':(?P<value>#?([/\w-]+))'
-        pattern = re.compile('^' + keyvalue_pattern + '$')
+        pattern = re.compile(keyvalue_pattern + '$')
         m = pattern.match(key_value)
         if not m:
             return False
@@ -2151,7 +2151,7 @@ ALL sets user:#all as the default include filter. Default: ORG.""")
     def _parse_hash(self, ftype, value):
         """Parse a hash pattern of type #n or user/repo#n"""
         hash_pattern = r'(?P<prefix>([\w-]+/[\w-]+)?)#(?P<nr>\d+)'
-        hash_pattern = re.compile('^' + hash_pattern + '$')
+        hash_pattern = re.compile(hash_pattern + '$')
         m = hash_pattern.match(value)
         if not m:
             return False
@@ -2169,7 +2169,7 @@ ALL sets user:#all as the default include filter. Default: ORG.""")
         """
         github_url = r'https://github.com/%s/pull/%s' % \
             (r'(?P<prefix>([\w-]+/[\w-]+))', r'(?P<nr>\d+)')
-        url_pattern = re.compile(r'^' + github_url + '$')
+        url_pattern = re.compile(github_url + '$')
         m = url_pattern.match(value)
         if not m:
             return False
@@ -2181,7 +2181,7 @@ ALL sets user:#all as the default include filter. Default: ORG.""")
     def _parse_branch_string(self, ftype, value):
         """Parse a branch string of type user/repo:branch"""
         branch_pattern = r'(?P<prefix>([\w-]+/[\w-]+)):(?P<branch>[\.\w-]+)'
-        branch_pattern = re.compile('^' + branch_pattern + '$')
+        branch_pattern = re.compile(branch_pattern + '$')
         m = branch_pattern.match(value)
         if not m:
             return False
@@ -2194,7 +2194,7 @@ ALL sets user:#all as the default include filter. Default: ORG.""")
            https://github.com/user/repo/tree/<branch>"""
         github_url = r'https://github.com/%s/tree/%s' % \
             (r'(?P<prefix>([\w-]+/[\w-]+))', r'(?P<branch>[\.\w-]+)')
-        url_pattern = re.compile(r'^' + github_url + '$')
+        url_pattern = re.compile(github_url + '$')
         m = url_pattern.match(value)
         if not m:
             return False

--- a/test/unit/test_filters.py
+++ b/test/unit/test_filters.py
@@ -123,6 +123,25 @@ class TestFilteredPullRequestsCommand(MoxTestBase):
         self.filters[ftype] = {key: ['#' + value]}
         assert self.command.filters == self.filters
 
+    @pytest.mark.parametrize('ftype', ['include', 'exclude'])
+    @pytest.mark.parametrize('key', ['user/repo', 'user-1/repo-2'])
+    @pytest.mark.parametrize('value', [
+        'branch', 'branch-1', 'branch_1', 'branch_1.2.0-SNAPSHOT'])
+    def test_parse_branch_url(self, ftype, key, value):
+        self.command._parse_branch_url(
+            ftype, 'https://github.com/%s/tree/%s' % (key, value))
+        self.filters[ftype] = {key: [value]}
+        assert self.command.filters == self.filters
+
+    @pytest.mark.parametrize('ftype', ['include', 'exclude'])
+    @pytest.mark.parametrize('key', ['user/repo', 'user-1/repo-2'])
+    @pytest.mark.parametrize('value', [
+        'branch', 'branch-1', 'branch_1', 'branch_1.2.0-SNAPSHOT'])
+    def test_parse_branch_string(self, ftype, key, value):
+        self.command._parse_branch_string(ftype, '%s:%s' % (key, value))
+        self.filters[ftype] = {key: [value]}
+        assert self.command.filters == self.filters
+
 
 class FilteredPullRequestsCommandTest(MoxTestBase):
 


### PR DESCRIPTION
While the filter branch functionality is working and checked by an integration test, it fails to integrate a branch called `bf_5.3.0-SNAPSHOT`. This is a deficiency in the regexp logic when identifying candidate branches.

To fix this issue, this PR extends the _parse_filters() logic to actively parse tracking branches using regular expressions. Unit tests are also added covering the range of tracking branch names.

Support is also added for branch tracking using the full Github URL similarly to what is done for Pull Request inclusion.

To test this PR:
- check the unit tests are all passing on Travis including the newly added ones
- run the [integration tests](https://ci.openmicroscopy.org/view/Failing/job/SCC-merge) and check everything is green
- for the keen ones, fork an upstream organization repository e.g. https://github.com/openmicroscopy/snoopys-sandbox, create a local branch with 1 commit ahead of the base branch, name it with a string composed of [a-Z0-9_-.], push this branch to your fork but do not create a Pull Request. Then locally reset to the HEAD to the base branch and try to merge your remote branch using one of the 2 forms:

  ````
  git reset --hard origin/<base_branch>
  python /path/to/snoopycrimecop/scc/main.py merge <base_branch> -Dnone -I <username>/<repo>:<branch_with-and.>
  python /path/to/snoopycrimecop/scc/main.py merge <base_branch> -Dnone -I https://github.com/<username>/<repo>/tree/<branch_with-and.>
  `````
  
  In both cases the command should merge the remote branch locally.