### PR TITLE
Fix flake8 E305 error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ class PyTest(TestCommand):
         errno = pytest.main(self.test_args)
         sys.exit(errno)
 
+
 try:
     from yaclifw.version import get_git_version
     from scc import __file__ as module_file


### PR DESCRIPTION
Fix the new warnings flagged by the latest version of `flake8`. Travis should remain green.