### PR TITLE
Comment filter

### DIFF
--- a/scc/git.py
+++ b/scc/git.py
@@ -857,7 +857,10 @@ class GitHubRepository(object):
     def filter_pull(self, pullrequest, filters):
 
         def is_whitelisted_comment(x):
-            return self.is_whitelisted(x.user, filters["include"].get("user"))
+            # Always include the organization filter for whitelisting comments
+            user_filters = filters["include"].setdefault("user", [])
+            user_filters.append('#org')
+            return self.is_whitelisted(x.user, user_filters)
 
         if pullrequest.parse(filters["exclude"].get("label"),
                              whitelist=is_whitelisted_comment):

--- a/scc/git.py
+++ b/scc/git.py
@@ -1669,7 +1669,6 @@ class GitRepository(object):
 
         for submodule_repo in self.submodules:
             # Create submodule filters
-            import copy
             sub_filters = copy.deepcopy(filters)
             # Do not copy top-level PRs
             for ftype in ["include", "exclude"]:

--- a/scc/git.py
+++ b/scc/git.py
@@ -22,6 +22,7 @@
 
 import argparse
 import re
+import copy
 import os
 import sys
 import uuid
@@ -858,7 +859,8 @@ class GitHubRepository(object):
 
         def is_whitelisted_comment(x):
             # Always include the organization filter for whitelisting comments
-            user_filters = filters["include"].setdefault("user", [])
+            user_filters = copy.deepcopy(filters["include"].setdefault(
+                "user", []))
             user_filters.append('#org')
             return self.is_whitelisted(x.user, user_filters)
 
@@ -1609,7 +1611,6 @@ class GitRepository(object):
 
         for submodule_repo in self.submodules:
             # Create submodule filters
-            import copy
             sub_filters = copy.deepcopy(filters)
             for ftype in ["include", "exclude"]:
                 sub_filters.pop("pr", None)  # Do not copy top-level PRs

--- a/test/integration/test_merge.py
+++ b/test/integration/test_merge.py
@@ -140,14 +140,25 @@ class TestMergePullRequest(MergeTest):
         self.pr.create_issue_comment('--exclude')
         self.merge()
         assert not self.isMerged()
+        self.merge('-Dnone', '-Iuser:#org')
+        assert self.isMerged()
 
     def testIncludeComment(self):
+        """"Test PR inclusion using whitelisted comment"""
 
-        self.pr.create_issue_comment('--foo')
+        self.pr.create_issue_comment('--foo\n--exclude')
         self.merge()
+        # Default set of filters recognize --exclude comment
         assert not self.isMerged()
-        self.merge('-Dnone','-Ifoo')
+        self.merge('-Dnone', '-Ifoo')
+        # --foo comment should be whitelisted
         assert self.isMerged()
+        self.merge('-Dnone', '-Ifoo', '-Eexclude')
+        # --exclude filter takes priority
+        assert not self.isMerged()
+        self.merge('-Ifoo')
+        # Default set of filters recognize --exclude comment
+        assert not self.isMerged()
 
     def testExcludeDescription(self):
 

--- a/test/integration/test_merge.py
+++ b/test/integration/test_merge.py
@@ -143,10 +143,10 @@ class TestMergePullRequest(MergeTest):
 
     def testIncludeComment(self):
 
-        self.pr.create_issue_comment('--breaking')
+        self.pr.create_issue_comment('--foo')
         self.merge()
         assert not self.isMerged()
-        self.merge('-Dnone', '-Iuser:#org', '-Ibreaking', '-Eexclude')
+        self.merge('-Dnone','-Ifoo')
         assert self.isMerged()
 
     def testExcludeDescription(self):


### PR DESCRIPTION
This PR is a proposal to address https://github.com/openmicroscopy/snoopycrimecop/issues/214. See the issue for more context about the application of the PR

### Current status and limitations

This PR works under the current assumptions:
- the default filter semantics used for the ci-master merge builds is unchanged, i.e. all PRs considered for inclusion should be opened by a public member of the organization or labelled as `include` and neither labelled as `breaking` nor labelled as `exclude`
- developers want to have the ability to label their PRs via comments and have them deployed in isolation from the main CI

A limitation of the current implementation is that the comment labelling is tightly coupled to the users filters. This implies that for a command like `scc merge -Dnone -Ilabel`, PR comments of type `--label`
will not be treated as labels.

### Implementation

This proposal redefines the whitelisting mechanism for labelling PRs by comment. With this change, comments made by public members of the organization comments are always treated as labels independently of the set of filters passed to the command.

In term of use case, assuming a PR has been opened against a repository and commented by a public member of the organization with a `--label` command, with the following command:

```
scc merge master --info -Dnone -Ilabel
```

should not be listed as a candidate with the previous release of scc but should be listed with this set of changes.

Additionally, the `test_merge.testIncludeComment` has been extended to cover the semantics with various versions of the merge command.

/cc @aleksandra-tarkowska 
