### PR TITLE
Improve unicode handling when listing excluded PRs

### DIFF
--- a/scc/git.py
+++ b/scc/git.py
@@ -846,8 +846,9 @@ class GitHubRepository(object):
 
         if excluded_pulls:
             msg += "Excluded PRs:\n"
-            for pull in excluded_pulls.keys():
-                msg += str(pull) + " (%s)" % excluded_pulls[pull] + "\n"
+            msg += "\n".join(["%s (%s)" % (str(key), str(value))
+                              for key, value in excluded_pulls.iteritems()])
+            msg += "\n"
 
         self.candidate_pulls.sort(lambda a, b:
                                   cmp(a.get_number(), b.get_number()))


### PR DESCRIPTION
Addresses https://github.com/openmicroscopy/snoopycrimecop/issues/188#issuecomment-277230120

For PR which titles contains Unicode (as the ones truncated by GitHub from long commit headers), the formatting of the exclusion PRs in the log was causing UnicodeDecodeError.

No integration tests added yet. However this could be functionally tested as follows.

From a repository with open PRs containing Unicode characters in their title, force the PR(s) to be excluded and check the current version of `scc merge` is throwing an error, e.g. using the current state of https://github.com/IDR/idr-metadata, the following command should fail

```
scc merge master --info -Euser:eleanorwilliams
```

With this PR included, the same command should complete and list the excluded PRs.