### PR TITLE
Read token from SCC_GITHUB_TOKEN env-var if set

### DIFF
--- a/scc/git.py
+++ b/scc/git.py
@@ -185,6 +185,8 @@ def get_token(local=False):
     """
     Get the GitHub API token.
     """
+    if os.getenv('SCC_GITHUB_TOKEN'):
+        return os.getenv('SCC_GITHUB_TOKEN')
     return git_config("github.token", local=local)
 
 

--- a/scc/git.py
+++ b/scc/git.py
@@ -185,8 +185,8 @@ def get_token(local=False):
     """
     Get the GitHub API token.
     """
-    if os.getenv('SCC_GITHUB_TOKEN'):
-        return os.getenv('SCC_GITHUB_TOKEN')
+    if os.getenv('GITHUB_TOKEN'):
+        return os.getenv('GITHUB_TOKEN')
     return git_config("github.token", local=local)
 
 


### PR DESCRIPTION
When using `scc` as a library (e.g. in scripts) it is sometimes necessary to override the github token set in gitconfig. This adds the environment variable `SCC_GITHUB_TOKEN`.