### PR TITLE
Limit pytest<3.3 for Python 2.6 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -126,5 +126,5 @@ setup(name='scc',
       version=VERSION,
 
       cmdclass={'test': PyTest},
-      tests_require=['pytest', 'restview', 'mox'],
+      tests_require=['pytest<3.3', 'restview', 'mox'],
       )


### PR DESCRIPTION
https://pypi.python.org/pypi/attrs/17.3.0 mentions
Python3 and backware-incompatible changes. Trying
to restrict it after a failed Jenkins jobs:

https://ci.openmicroscopy.org/view/Failing/job/SCC-merge/933/console