### PR TITLE
external-issues: new command for listing non-team issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-yaclifw>=0.1.2
+yaclifw==0.1.2
 PyGithub
 PyYAML==3.11
 six

--- a/scc/git.py
+++ b/scc/git.py
@@ -2972,6 +2972,37 @@ class ExternalIssues(GitHubCommand):
             print "\n".join(sorted(issues))
 
 
+class UnsubscribedRepos(GitHubCommand):
+    """
+    Find repositories which the current user is not subscribed to
+    """
+
+    NAME = "unsubscribed-repos"
+
+    def __init__(self, sub_parsers):
+        super(UnsubscribedRepos, self).__init__(sub_parsers)
+
+        self.parser.add_argument(
+            'orgs', nargs="+",
+            help="organizations that should be checked")
+
+    def __call__(self, args):
+        super(UnsubscribedRepos, self).__call__(args)
+        self.login(args)
+        login = self.gh.get_login()
+        for org in args.orgs:
+            print org
+            org = self.gh.get_organization(org)
+            for repo in org.get_repos():
+                found = False
+                for user in repo.get_subscribers():
+                    if user.login == login:
+                        found = True
+                        break
+                if not found:
+                    print "\t", repo.name
+
+
 class Label(GitHubCommand):
     """
     Query/add/remove labels from GitHub issues.

--- a/scc/main.py
+++ b/scc/main.py
@@ -45,6 +45,7 @@ from git import SetCommitStatus
 from git import TagRelease
 from git import Token
 from git import TravisMerge
+from git import UnsubscribedRepos
 from git import UpdateSubmodules
 from deploy import Deploy
 from version import Version
@@ -75,6 +76,7 @@ def entry_point():
             (TagRelease.NAME, TagRelease),
             (TravisMerge.NAME, TravisMerge),
             (Version.NAME, Version),
+            (UnsubscribedRepos.NAME, UnsubscribedRepos),
             (UpdateSubmodules.NAME, UpdateSubmodules),
             ])
     except Stop, stop:

--- a/scc/main.py
+++ b/scc/main.py
@@ -35,6 +35,7 @@ from git import CheckMilestone
 from git import CheckPRs
 from git import CheckStatus
 from git import DeleteTags
+from git import ExternalIssues
 from git import Label
 from git import Merge
 from git import MilestoneCommand
@@ -64,6 +65,7 @@ def entry_point():
             (Deploy.NAME, Deploy),
             (DeleteTags.NAME, DeleteTags),
             (Label.NAME, Label),
+            (ExternalIssues.NAME, ExternalIssues),
             (Merge.NAME, Merge),
             (MilestoneCommand.NAME, MilestoneCommand),
             (Rate.NAME, Rate),


### PR DESCRIPTION
Since there is currently no search filter for "members-only",
this loops through the given organizations, loads all team members,
and constructs a query of the form: "-author:member1 -author:member2".