### PR TITLE
setup.py: Remove pytest <3.3 limitation which breaks python 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -125,5 +125,5 @@ setup(name='scc',
       version=VERSION,
 
       cmdclass={'test': PyTest},
-      tests_require=['pytest<3.3', 'restview', 'mox'],
+      tests_require=['pytest', 'restview', 'mox'],
       )


### PR DESCRIPTION
To test new job; not for merging.