### PR TITLE
Recursive merge bug fixes and improvements

### DIFF
--- a/scc/git.py
+++ b/scc/git.py
@@ -1958,6 +1958,7 @@ class GitRepository(object):
         """Recursively push a branch to remotes across submodules"""
 
         full_remote = remote % (self.origin.repo_name)
+        self.gh.get_user().create_fork(self.origin.repo)
         self.push_branch(branch_name, remote=full_remote, force=force)
         self.dbg("Pushed %s to %s" % (branch_name, full_remote))
 

--- a/scc/git.py
+++ b/scc/git.py
@@ -1957,16 +1957,16 @@ class GitRepository(object):
     def rpush(self, branch_name, remote, force=False):
         """Recursively push a branch to remotes across submodules"""
 
-        full_remote = remote % (self.origin.repo_name)
-        self.gh.get_user().create_fork(self.origin.repo)
-        self.push_branch(branch_name, remote=full_remote, force=force)
-        self.dbg("Pushed %s to %s" % (branch_name, full_remote))
-
         for submodule_repo in self.submodules:
             try:
                 submodule_repo.rpush(branch_name, remote, force=force)
             finally:
                 self.cd(self.path)
+
+        full_remote = remote % (self.origin.repo_name)
+        self.gh.get_user().create_fork(self.origin.repo)
+        self.push_branch(branch_name, remote=full_remote, force=force)
+        self.dbg("Pushed %s to %s" % (branch_name, full_remote))
 
     def __del__(self):
         # We need to make sure our logging wrappers are closed when this

--- a/scc/git.py
+++ b/scc/git.py
@@ -1837,7 +1837,7 @@ class GitRepository(object):
 
                 # Substitute submodule URL using connection login
                 user = self.gh.get_login()
-                pattern = '(.*github.com[:/]).*(/.*.git)'
+                pattern = '(.*github.com[:/]).*(/.*(.git)?)'
                 new_url = re.sub(pattern, r'\1%s\2' % user, submodule_url)
                 git_config(config_url, config_file=".gitmodules",
                            value=new_url)


### PR DESCRIPTION
Tested in the context of the ansible-roles repository (see https://trello.com/c/ruRyhHyP/22-ansible-roles-testing), this PR contains a series of improvements to increase the scalability of `scc merge` for repositories with submodules.

- 2de5192 fixes the regexp pattern to allow `--update-gitmodules` to update URLs with or without trailing `.git`
- 625c024 inverts the pushing order, pushing submodule branches before the upstream branches. In the case of repositories with large number of submodules where branch pushing trigger builds like Travis, this prevents race conditions as the top-level repository branch could point to not-existing submodule commits
- d610888 uses the GitHub `create_fork()` API before pushing branches. If the fork exists, this should be a no-op else the fork will be created.

With the systematic usage of integration branches separated by `_` rather than `/`, the last commits means there should be no need for any manual action when new organizational repositories are created as `scc merge --push --update-gitmodules` should be self-sufficient.

Testing this PR:
- Continuous Integration: check Travis and [Jenkins](https://ci.openmicroscopy.org/job/SCC-merge/974/)
- clone https://github.com/ome/ansible-roles (ideally without forking it) and run the merge command

   ```
   git clone https://github.com/ome/ansible-roles
   cd ansible-roles && git submodule update --init
   virtualenv /tmp/venv
   /tmp/venv/bin/pip install -r requirements.txt # yaclifw
   /tmp/venv/bin/python scc/main.py merge master --push master_merge_trigger --update-gitmodules
   ```

   The command should recursively fork the top-level project as well as all unforked submodule repositories, run the recursive merge command and push the integration branches. Check that the submodule branches are pushed before the top-level branch

   Re-running the merge command after the first execution should have the same effect but the repository forking should be skipped

   ```
   git reset --hard origin/master && git submodule update
   /tmp/venv/bin/python scc/main.py merge master --push master_merge_trigger  --update-gitmodules
   ```
  
Fixes #230