### PR TITLE
Fix rate limiting calls following upstream API breakage

### DIFF
--- a/scc/git.py
+++ b/scc/git.py
@@ -34,6 +34,7 @@ import difflib
 import socket
 import yaml
 import six
+import warnings
 from ssl import SSLError
 from yaclifw.framework import Command, Stop
 
@@ -320,6 +321,9 @@ class GHManager(object):
             'reset', 'limit', 'remaining', 'name', and 'time'
             which is a readable version of 'reset'.
         """
+        warnings.warn(
+            "This method is deprecated. Use get_rate_limit instead.",
+            DeprecationWarning)
         limits = dict(self.github.get_rate_limit()._rawData)
         core = limits["resources"]["core"]
         search = limits["resources"]["search"]

--- a/scc/git.py
+++ b/scc/git.py
@@ -2038,8 +2038,8 @@ class GitHubCommand(Command):
             # PyGithub 1.43 and above
             core = r.core
         logging.getLogger('scc.gh').debug(
-            "%s remaining from %s (Reset at %s" % (
-            core.remaining, core.limit, core.reset.strftime("%H:%m")))
+            "%s remaining from %s (Reset at %s" %
+            (core.remaining, core.limit, core.reset.strftime("%H:%m")))
 
     def parse_pr(self, line):
         m = self.pr_pattern.match(line)
@@ -3123,8 +3123,8 @@ class Rate(GitHubCommand):
 
         for key in rates:
             if rates[key]:
-                print ("%s: %s remaining from %s. Reset at %s" % (
-                       key, rates[key].remaining, rates[key].limit,
+                print ("%s: %s remaining from %s. Reset at %s" %
+                       (key, rates[key].remaining, rates[key].limit,
                         rates[key].reset.strftime("%H:%m")))
 
 

--- a/scc/git.py
+++ b/scc/git.py
@@ -2036,11 +2036,12 @@ class GitHubCommand(Command):
     def show_rate(self):
         r = self.gh.get_rate_limit()
         try:
-            # PyGithub 1.42 and below
-            core = r.rate
-        except AttributeError:
             # PyGithub 1.43 and above
             core = r.core
+        except AttributeError:
+            # PyGithub 1.42 and below
+            core = r.rate
+
         logging.getLogger('scc.gh').debug(
             "%s remaining from %s (Reset at %s" %
             (core.remaining, core.limit, core.reset.strftime("%H:%m")))
@@ -3117,13 +3118,13 @@ class Rate(GitHubCommand):
 
         rates = {"core": None, "search": None, "graphql": None}
         try:
-            # PyGithub 1.42 and lower
-            rates["core"] = r.rate
-        except AttributeError:
             # PyGithub 1.43 and above
             rates["core"] = r.core
             rates["search"] = r.search
             rates["graphql"] = r.graphql
+        except AttributeError:
+            # PyGithub 1.42 and lower
+            rates["core"] = r.rate
 
         for key in rates:
             if rates[key]:


### PR DESCRIPTION
PyGithub 1.43 introduces a breaking change in the RateLimit API modifying both the internal representation as well as the methods of the Rate objects - see https://github.com/PyGithub/PyGithub/commit/fd8a036 and https://github.com/PyGithub/PyGithub/pull/902. This causes scc to crash when the latest version of PyGithub (currently 1.43.1) is installed.

Rather than capping PyGithub or forcing an upgrade, this PR adds backwards-compatible support for the new rate limit API with the following changes:
- the get_rate_limits() method is deprecated
- a new get_rate_limit() method forwards the calls to GitHub.get_rate_limit()
- all internal usages of rate limits are updated to use get_rate_limit. A try/exept block is added to handle older and newer version of PyGithub and return the core rate as well as the search and graphql rates for recent versions.

To test this PR:
1- create a new virtualenv, install `requirements.txt` and check that e.g. `scc rate` fails with a KeyError
2- with the same virtualenv, run `/path/to/venv/python/scc/main.py rate` from this branch and check the command returns the `core`, `search` and `graphql` rates
3- check the backwards compatibility by downgrading PyGithub (or creating a new virtualenv) and check that `/path/to/venv/python/scc/main.py rate` returns the `core` rate only

Proposed tag: 0.10.1