### PR TITLE
Always pass a Loader argument to yaml.load

### DIFF
--- a/scc/git.py
+++ b/scc/git.py
@@ -1061,7 +1061,7 @@ class GitRepository(object):
             self.dbg("Reading repository configuration from %s" %
                      (repository_config))
             with open(self.repository_config) as fh:
-                self.repository_config = yaml.load(fh)
+                self.repository_config = yaml.load(fh, Loader=yaml.FullLoader)
         if self.repository_config is not None:
             self.dbg("Repository configuration:\n%s" %
                      (yaml.dump(self.repository_config)))
@@ -4119,7 +4119,7 @@ class BumpVersionConda(GitRepoCommand):
                 if fn == self.META_FILE:
                     fullpath = os.path.join(dirpath, fn)
                     with open(fullpath) as fp:
-                        data = yaml.load(fp)
+                        data = yaml.load(fp, Loader=yaml.FullLoader)
                     # find information about the repository
                     jinja2 = {}
                     with open(fullpath) as file:
@@ -4231,7 +4231,7 @@ class BumpVersionConda(GitRepoCommand):
                     yaml.indent(mapping=2)
                     # read the meta files and update the value
                     with open(fullpath) as fp:
-                        data = yaml.load(fp)
+                        data = yaml.load(fp, Loader=yaml.FullLoader)
                     if data["source"][self.KEY_SHA] and \
                        self.KEY_SHA not in jinja2.keys():
                         data["source"][self.KEY_SHA] = sha256


### PR DESCRIPTION
Since PyYAML 5.1, calling `yaml.load()` without specifying a `Loader` argument is deprecated. With the release of PyYAML 6.0 yesterday, the `Loader` is now a mandatory positional argument.

This causes `scc` commands loading YAML configurations e.g. `merge --repository-config` (see https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-push/1006/console ) or the newly introduced `bump-conda-version` to fail on newly created environments - see also https://github.com/yaml/pyyaml/issues/576

This PR adjusts all usages of `yaml.load()` to pass `Loader=yaml.FullLoader` which is equivalent to the former call. This should make the library compatible with both PyYAML 5.x and PyYAML 6.x. The alternative would be to cap PyYAML to 5.x but this feels like a minimal change to maintain compatibility between both lines. The only open question is around the loader to use. feb2c22  uses the `FullLoader` which is identical to the previous call but there might be  a case for tightening it to `SafeLoader`. 

To test this PR:

- create a new Python virtual environment and run `/path/to/venv/bin/pip install scc` - this should install `PyYAML 6.0`
- using https://github.com/ome/bio-formats-build, run the following command
  ```
  /path/to/venv/bin/scc merge --info master --repository-config=scripts/repositories.yml 
  ```
  this should fail with the same error as indicated above
- checkout this branch and re-install `scc` in the same virtual environment `/path/to/venv/bin/pip install .` Running the same command as above should now execute the command as expected
